### PR TITLE
specify counts columns in manual_drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.1.1
+- Minor bug fix to make it possible to add `wells` or `barcodes` to the `manual_drops` specified for each plate.
+
 ### version 3.1.0
 - Configured to enable plate-level indices to be embedded in the round-1 PCR primers (see [this issue](https://github.com/jbloomlab/seqneut-pipeline/issues/40)). Essentially, this amounts to allowing a per-plate flanking sequence to be specified for each plate, and only FASTQ reads with that flanking sequence are read for that plate. Typically this index would be specified as `upstream2` in the [illuminabarcodeparser](https://jbloomlab.github.io/dms_variants/dms_variants.illuminabarcodeparser.html). To enable this change, altered the configuration from the previous setup of just having a single global `illumina_barcode_parser_params` applied to all plates. Now such a global parser is still specified that has default values that you want to apply to all plates. But in addition, in the per-plate configuration you can specify `illumina_barcode_parser_params` that are added to (and override) anything in the global parser params, and can contain plate specific `upstream2` and other relevant setting (eg, `upstream2_mismatch`). The test example was modified to use this option for plate2 and plate11.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 #### version 3.1.1
-- Minor bug fix to make it possible to add `wells` or `barcodes` to the `manual_drops` specified for each plate.
+- Minor bug fix to make it possible to add `wells` or `barcodes` to the `manual_drops` specified for each plate. Addresses [this issue](https://github.com/jbloomlab/neutcurve/issues/45).
 
 ### version 3.1.0
 - Configured to enable plate-level indices to be embedded in the round-1 PCR primers (see [this issue](https://github.com/jbloomlab/seqneut-pipeline/issues/40)). Essentially, this amounts to allowing a per-plate flanking sequence to be specified for each plate, and only FASTQ reads with that flanking sequence are read for that plate. Typically this index would be specified as `upstream2` in the [illuminabarcodeparser](https://jbloomlab.github.io/dms_variants/dms_variants.illuminabarcodeparser.html). To enable this change, altered the configuration from the previous setup of just having a single global `illumina_barcode_parser_params` applied to all plates. Now such a global parser is still specified that has default values that you want to apply to all plates. But in addition, in the per-plate configuration you can specify `illumina_barcode_parser_params` that are added to (and override) anything in the global parser params, and can contain plate specific `upstream2` and other relevant setting (eg, `upstream2_mismatch`). The test example was modified to use this option for plate2 and plate11.

--- a/notebooks/process_plate.py.ipynb
+++ b/notebooks/process_plate.py.ipynb
@@ -296,6 +296,10 @@
     "                )\n",
     "            )[\"barcode_serum_replicate\"].isin(qc_drops[filter_type])\n",
     "        ]\n",
+    "    elif filter_type == \"wells\":\n",
+    "        counts = counts[~counts[\"well\"].isin(qc_drops[filter_type])]\n",
+    "    elif filter_type == \"barcodes\":\n",
+    "        counts = counts[~counts[\"barcode\"].isin(qc_drops[filter_type])]\n",
     "    else:\n",
     "        assert filter_type in set(counts.columns)\n",
     "        counts = counts[~counts[filter_type].isin(qc_drops[filter_type])]"
@@ -1501,7 +1505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request should resolve #45 by adding additional `elif` statements to a cell of `process_plate.ipynb` where manual_drops are removed from the `counts` dataframe. I tested this with multiple `wells` on some recent H3N2 `ngs-neut` data. 

As is, single wells/barcodes cannot be specified in lists (as indicated in `README`). They must be added as individual lines with dashes. If this is expected behavior, ignore this comment. Otherwise, I can add this detail to `README`?