### PR TITLE
remove `defaults` from `conda` envs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,12 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: build conda environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: seqneut-pipeline
           environment-file: environment.yml
@@ -60,7 +60,7 @@ jobs:
         run: cd test_example && python test_titers_as_expected.py && cd ..
 
       - name: upload results in case of error
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### version 3.1.3
 - Remove `defaults` channel from `conda` envs to avoid issue with Anaconda licensing.
+- Update `snakemake` version.
 
 #### version 3.1.2
 - Minor bug fix to resolve issue with specifying serum_replicates and barcode_serum_replicates to manual drops, similar issue resolved in 3.1.1. Addresses [this issue](https://github.com/jbloomlab/seqneut-pipeline/issues/49).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.1.3
+- Remove `defaults` channel from `conda` envs to avoid issue with Anaconda licensing.
+
 #### version 3.1.2
 - Minor bug fix to resolve issue with specifying serum_replicates and barcode_serum_replicates to manual drops, similar issue resolved in 3.1.1. Addresses [this issue](https://github.com/jbloomlab/seqneut-pipeline/issues/49).
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - python=3.12
   - ruamel.yaml=0.18.6
   - snakefmt
-  - snakemake=8.10
+  - snakemake=8.20.6
   - ruff
   - pip:
     - dms_variants==1.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ name: seqneut-pipeline
 channels:
   - conda-forge
   - bioconda
-  - defaults
 
 dependencies:
   - altair=5.2

--- a/envs/count_barcodes.yml
+++ b/envs/count_barcodes.yml
@@ -3,7 +3,6 @@ name: seqneut-pipeline
 channels:
   - conda-forge
   - bioconda
-  - defaults
 
 dependencies:
   - pandas=2.2


### PR DESCRIPTION
Removing this channel fixes issue with Anaconda licensing.