### PR TITLE
make pipeline runnable w precomputed counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### version 3.4.0
+- Make the pipeline run OK even if FASTQs are not available if the counts have already been computed (see [here](https://github.com/jbloomlab/seqneut-pipeline/pull/62)). This is designed to make it more portable. Specifically:
+  - default `.gitignore` and README now suggest tracking the barcode fates files as well as the counts files, as they are needed by downstream pipeline steps.
+  - the invalid barcodes are no longer considered an output of the pipeline as they are not tracked.
+
 ### version 3.3.0
 - In internal functioning of `seqneut-pipeline.smk`, make *viral_libraries* and *neut_standard_sets* Python variables passed as params rather than CSVs passed as input file (see [here](https://github.com/jbloomlab/seqneut-pipeline/pull/60)). The advantage of this is altering the CSVs holding the viral libraries and neutralization standards now only triggers a pipeline re-run if the relevant content has changed rather than always. Specifically:
   - *viral_libraries* is now a dict of data frames rather than a dict of CSVs.

--- a/README.md
+++ b/README.md
@@ -490,13 +490,13 @@ The output is that for each plate, the following files are created:
 
 ## Results of running the pipeline
 The results of running the pipeline are put in the `./results/` subdirectory of your main repo.
-We recommend using the `.gitignore` file in [./test_example/.gitignore] in your main repo to only track key results in your GitHub repo.
+We recommend using the `.gitignore` file in [./test_example/.gitignore](test_example/.gitignore) in your main repo to only track key results in your GitHub repo.
 The key results if the pipeline runs to completion are in `./results/aggregated_titers/titers_{group}.csv` for each group of sera.
 The set of full created outputs are as follows (note only some will be tracked depending on your `.gitignore`):
 
   - Outputs related to barcode counting:
     - `./results/barcode_counts/`: files giving the barcode counts for each sample. You should track this in the repo.
-    - `./results/barcode_fates/`: files giving the statistics (fates) of reads in the barcode counting for each sample. You do not need to track this in the repo as the results are plotted.
+    - `./results/barcode_fates/`: files giving the statistics (fates) of reads in the barcode counting for each sample. You should track this in the repo.
     - `./results/barcode_invalid/`: files giving counts of invalid barcodes for each sample. You do not need to track this in the repo, but it could be helpful to look at these identities in counts if QC shows you are getting many invalid barcodes.
 
   - Outputs related to processing each plate:

--- a/seqneut-pipeline.smk
+++ b/seqneut-pipeline.smk
@@ -354,7 +354,7 @@ if plates:
             f"results/miscellaneous_plates/{plate}/{well}_{suffix}"
             for plate in miscellaneous_plates
             for well in miscellaneous_plates[plate]["wells"]
-            for suffix in ["counts.csv", "invalid.csv", "fates.csv"]
+            for suffix in ["counts.csv", "fates.csv"]
         ],
     ]
 
@@ -364,6 +364,6 @@ else:
             f"results/miscellaneous_plates/{plate}/{well}_{suffix}"
             for plate in miscellaneous_plates
             for well in miscellaneous_plates[plate]["wells"]
-            for suffix in ["counts.csv", "invalid.csv", "fates.csv"]
+            for suffix in ["counts.csv", "fates.csv"]
         ],
     ]

--- a/test_example/.gitignore
+++ b/test_example/.gitignore
@@ -12,6 +12,10 @@ results/*
 results/barcode_counts/*
 !results/barcode_counts/*.csv
 
+!results/barcode_fates
+results/barcode_fates/*
+!results/barcode_fates/*.csv
+
 !results/plates
 results/plates/*/*
 !results/plates/*/frac_infectivity.csv
@@ -36,3 +40,4 @@ results/qc_drops/*
 !results/miscellaneous_plates
 results/miscellaneous_plates/*/*
 !results/miscellaneous_plates/*/*counts.csv
+!results/miscellaneous_plates/*/*fates.csv

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_100.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_100.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,66657
+low quality barcode,18263
+unparseable barcode,2185
+invalid barcode,395
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_12800.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_12800.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65422
+low quality barcode,19308
+unparseable barcode,2164
+invalid barcode,606
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_1600.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_1600.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,66390
+low quality barcode,18198
+unparseable barcode,2369
+invalid barcode,543
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_200.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_200.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,67256
+low quality barcode,15598
+unparseable barcode,4212
+invalid barcode,434
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_3200.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_3200.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,66649
+low quality barcode,17673
+unparseable barcode,2423
+invalid barcode,755
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_400.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_400.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65103
+low quality barcode,19163
+unparseable barcode,2525
+invalid barcode,709
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_6400.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_6400.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,68271
+low quality barcode,16456
+unparseable barcode,2133
+invalid barcode,640
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_800.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_A23038d0_r32_75K_800.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,66646
+low quality barcode,17685
+unparseable barcode,2533
+invalid barcode,636
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-1.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-1.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,66830
+low quality barcode,17704
+unparseable barcode,2402
+invalid barcode,564
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-2.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-2.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65544
+low quality barcode,18326
+unparseable barcode,3133
+invalid barcode,497
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-3.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-3.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,66223
+low quality barcode,18232
+unparseable barcode,2383
+invalid barcode,662
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-4.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-4.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65864
+low quality barcode,18899
+unparseable barcode,2181
+invalid barcode,556
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-5.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-5.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,67459
+low quality barcode,17209
+unparseable barcode,2157
+invalid barcode,675
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-6.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-6.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65410
+low quality barcode,18693
+unparseable barcode,2790
+invalid barcode,607
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-7.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-7.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65640
+low quality barcode,18901
+unparseable barcode,2284
+invalid barcode,675
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/H3N2_plate_none-8.csv
+++ b/test_example/results/barcode_fates/H3N2_plate_none-8.csv
@@ -1,0 +1,7 @@
+fate,count
+valid barcode,65851
+low quality barcode,17781
+unparseable barcode,3111
+invalid barcode,757
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_131220.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_131220.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49368
+valid barcode,37793
+low quality barcode,8315
+invalid barcode,3092
+unparseable barcode,1432
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_14580.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_14580.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49270
+valid barcode,38288
+low quality barcode,7750
+invalid barcode,3257
+unparseable barcode,1435
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_1620.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_1620.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49221
+valid barcode,37799
+low quality barcode,8432
+invalid barcode,3139
+unparseable barcode,1409
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_180.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_180.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49279
+valid barcode,39092
+low quality barcode,8051
+invalid barcode,2105
+unparseable barcode,1473
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_20.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_20.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49097
+valid barcode,40558
+low quality barcode,8078
+unparseable barcode,1928
+invalid barcode,339
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_393660.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_393660.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49363
+valid barcode,38716
+low quality barcode,8322
+invalid barcode,2224
+unparseable barcode,1375
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_43740.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_43740.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49324
+valid barcode,37504
+low quality barcode,8347
+invalid barcode,3520
+unparseable barcode,1305
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_4860.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_4860.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49348
+valid barcode,37649
+low quality barcode,7910
+invalid barcode,3749
+unparseable barcode,1344
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_540.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_540.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49371
+valid barcode,38873
+low quality barcode,8567
+unparseable barcode,1743
+invalid barcode,1446
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d0_60.csv
+++ b/test_example/results/barcode_fates/plate11_M099d0_60.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49055
+valid barcode,40701
+low quality barcode,7831
+unparseable barcode,1989
+invalid barcode,424
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_131220.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_131220.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49379
+valid barcode,37998
+low quality barcode,8381
+invalid barcode,2963
+unparseable barcode,1279
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_14580.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_14580.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49413
+valid barcode,38478
+low quality barcode,8134
+invalid barcode,2721
+unparseable barcode,1254
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_1620.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_1620.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49383
+valid barcode,34970
+low quality barcode,8235
+invalid barcode,6157
+unparseable barcode,1255
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_180.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_180.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49038
+valid barcode,41677
+low quality barcode,6998
+unparseable barcode,1913
+invalid barcode,374
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_20.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_20.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49034
+valid barcode,40829
+low quality barcode,7810
+unparseable barcode,1991
+invalid barcode,336
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_393660.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_393660.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49376
+valid barcode,38758
+low quality barcode,8459
+invalid barcode,2114
+unparseable barcode,1293
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_43740.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_43740.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49341
+valid barcode,37189
+low quality barcode,8155
+invalid barcode,4001
+unparseable barcode,1314
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_4860.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_4860.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49384
+valid barcode,38189
+low quality barcode,8315
+invalid barcode,2843
+unparseable barcode,1269
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_540.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_540.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49206
+valid barcode,35899
+low quality barcode,7508
+invalid barcode,5692
+unparseable barcode,1695
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_M099d30_60.csv
+++ b/test_example/results/barcode_fates/plate11_M099d30_60.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49099
+valid barcode,40956
+low quality barcode,7654
+unparseable barcode,1891
+invalid barcode,400
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_131220.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_131220.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49416
+valid barcode,37412
+low quality barcode,8167
+invalid barcode,3754
+unparseable barcode,1251
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_14580.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_14580.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49351
+valid barcode,35997
+low quality barcode,8364
+invalid barcode,5061
+unparseable barcode,1227
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_1620.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_1620.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49451
+valid barcode,29509
+invalid barcode,11603
+low quality barcode,8215
+unparseable barcode,1222
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_180.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_180.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49336
+valid barcode,40797
+low quality barcode,7722
+unparseable barcode,1673
+invalid barcode,472
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_20.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_20.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49024
+valid barcode,41659
+low quality barcode,7050
+unparseable barcode,1941
+invalid barcode,326
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_393660.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_393660.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49313
+valid barcode,37989
+low quality barcode,7911
+invalid barcode,3493
+unparseable barcode,1294
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_43740.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_43740.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49426
+valid barcode,38052
+low quality barcode,7421
+invalid barcode,3913
+unparseable barcode,1188
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_4860.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_4860.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49384
+valid barcode,35386
+low quality barcode,8531
+invalid barcode,5425
+unparseable barcode,1274
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_540.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_540.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49412
+valid barcode,34315
+low quality barcode,8600
+invalid barcode,6267
+unparseable barcode,1406
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_Y044d30_60.csv
+++ b/test_example/results/barcode_fates/plate11_Y044d30_60.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49083
+valid barcode,40396
+low quality barcode,8242
+unparseable barcode,1940
+invalid barcode,339
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_none-10.csv
+++ b/test_example/results/barcode_fates/plate11_none-10.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49357
+valid barcode,38187
+low quality barcode,8366
+invalid barcode,2777
+unparseable barcode,1313
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_none-11.csv
+++ b/test_example/results/barcode_fates/plate11_none-11.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49405
+valid barcode,38228
+low quality barcode,8050
+invalid barcode,3080
+unparseable barcode,1237
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_none-12.csv
+++ b/test_example/results/barcode_fates/plate11_none-12.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49351
+valid barcode,37911
+low quality barcode,8456
+invalid barcode,3015
+unparseable barcode,1267
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_none-2.csv
+++ b/test_example/results/barcode_fates/plate11_none-2.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49367
+valid barcode,37756
+low quality barcode,8493
+invalid barcode,3104
+unparseable barcode,1280
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_none-3.csv
+++ b/test_example/results/barcode_fates/plate11_none-3.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49339
+valid barcode,37828
+low quality barcode,8061
+invalid barcode,3386
+unparseable barcode,1386
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate11_none-4.csv
+++ b/test_example/results/barcode_fates/plate11_none-4.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49363
+valid barcode,38369
+low quality barcode,8225
+invalid barcode,2787
+unparseable barcode,1256
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_131220.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_131220.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49200
+valid barcode,35858
+low quality barcode,8814
+invalid barcode,4696
+unparseable barcode,1432
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_14580.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_14580.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49295
+valid barcode,36861
+low quality barcode,8902
+invalid barcode,3507
+unparseable barcode,1435
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_1620.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_1620.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49370
+valid barcode,36459
+low quality barcode,8107
+invalid barcode,4655
+unparseable barcode,1409
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_180.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_180.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49248
+valid barcode,37179
+low quality barcode,8918
+invalid barcode,3182
+unparseable barcode,1473
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_20.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_20.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48975
+valid barcode,41489
+low quality barcode,7332
+unparseable barcode,1928
+invalid barcode,276
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_393660.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_393660.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49262
+valid barcode,36478
+low quality barcode,8742
+invalid barcode,4143
+unparseable barcode,1375
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_43740.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_43740.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49371
+valid barcode,36701
+low quality barcode,8786
+invalid barcode,3837
+unparseable barcode,1305
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_4860.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_4860.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49308
+valid barcode,36520
+low quality barcode,8558
+invalid barcode,4270
+unparseable barcode,1344
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_540.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_540.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48886
+valid barcode,35251
+low quality barcode,8820
+invalid barcode,5300
+unparseable barcode,1743
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d0_60.csv
+++ b/test_example/results/barcode_fates/plate2_M099d0_60.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48956
+valid barcode,40949
+low quality barcode,7822
+unparseable barcode,1989
+invalid barcode,284
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_131220.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_131220.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49342
+valid barcode,36924
+low quality barcode,8479
+invalid barcode,3976
+unparseable barcode,1279
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_14580.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_14580.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49333
+valid barcode,36253
+low quality barcode,8734
+invalid barcode,4426
+unparseable barcode,1254
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_1620.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_1620.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49362
+valid barcode,31173
+invalid barcode,9700
+low quality barcode,8510
+unparseable barcode,1255
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_180.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_180.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49049
+valid barcode,40967
+low quality barcode,7808
+unparseable barcode,1913
+invalid barcode,263
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_20.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_20.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48975
+valid barcode,39994
+low quality barcode,8755
+unparseable barcode,1991
+invalid barcode,285
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_393660.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_393660.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49331
+valid barcode,36921
+low quality barcode,8425
+invalid barcode,4030
+unparseable barcode,1293
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_43740.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_43740.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49345
+valid barcode,36983
+low quality barcode,8315
+invalid barcode,4043
+unparseable barcode,1314
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_4860.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_4860.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49347
+valid barcode,34835
+low quality barcode,9123
+invalid barcode,5426
+unparseable barcode,1269
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_540.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_540.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49099
+valid barcode,36200
+low quality barcode,8186
+invalid barcode,4820
+unparseable barcode,1695
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_M099d30_60.csv
+++ b/test_example/results/barcode_fates/plate2_M099d30_60.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49010
+valid barcode,40549
+low quality barcode,8215
+unparseable barcode,1891
+invalid barcode,335
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_131220.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_131220.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49333
+valid barcode,36583
+low quality barcode,8742
+invalid barcode,4091
+unparseable barcode,1251
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_14580.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_14580.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49422
+valid barcode,35599
+low quality barcode,8770
+invalid barcode,4982
+unparseable barcode,1227
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_1620.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_1620.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49327
+valid barcode,31787
+low quality barcode,9098
+invalid barcode,8566
+unparseable barcode,1222
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_180.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_180.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48991
+valid barcode,35571
+low quality barcode,8990
+invalid barcode,4775
+unparseable barcode,1673
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_20.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_20.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49035
+valid barcode,41080
+low quality barcode,7627
+unparseable barcode,1941
+invalid barcode,317
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_393660.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_393660.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49393
+valid barcode,36783
+low quality barcode,8903
+invalid barcode,3627
+unparseable barcode,1294
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_43740.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_43740.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49386
+valid barcode,36085
+low quality barcode,9040
+invalid barcode,4301
+unparseable barcode,1188
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_4860.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_4860.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49342
+valid barcode,35923
+low quality barcode,8372
+invalid barcode,5089
+unparseable barcode,1274
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_540.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_540.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49182
+valid barcode,34627
+low quality barcode,8649
+invalid barcode,6136
+unparseable barcode,1406
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_Y154d182_60.csv
+++ b/test_example/results/barcode_fates/plate2_Y154d182_60.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48977
+valid barcode,40343
+low quality barcode,8459
+unparseable barcode,1940
+invalid barcode,281
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_none-10.csv
+++ b/test_example/results/barcode_fates/plate2_none-10.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49358
+valid barcode,36315
+low quality barcode,9190
+invalid barcode,3900
+unparseable barcode,1237
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_none-11.csv
+++ b/test_example/results/barcode_fates/plate2_none-11.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49382
+valid barcode,37390
+low quality barcode,8839
+invalid barcode,3122
+unparseable barcode,1267
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_none-2.csv
+++ b/test_example/results/barcode_fates/plate2_none-2.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49353
+valid barcode,36998
+low quality barcode,9270
+invalid barcode,3099
+unparseable barcode,1280
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_none-3.csv
+++ b/test_example/results/barcode_fates/plate2_none-3.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49275
+valid barcode,36395
+low quality barcode,8607
+invalid barcode,4337
+unparseable barcode,1386
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_none-4.csv
+++ b/test_example/results/barcode_fates/plate2_none-4.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49381
+valid barcode,36453
+low quality barcode,9234
+invalid barcode,3676
+unparseable barcode,1256
+read too short,0
+failed chastity filter,0

--- a/test_example/results/barcode_fates/plate2_none-9.csv
+++ b/test_example/results/barcode_fates/plate2_none-9.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49330
+valid barcode,36821
+low quality barcode,8830
+invalid barcode,3706
+unparseable barcode,1313
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B10_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B10_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49342
+valid barcode,36924
+low quality barcode,8479
+invalid barcode,3976
+unparseable barcode,1279
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B11_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B11_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49331
+valid barcode,36921
+low quality barcode,8425
+invalid barcode,4030
+unparseable barcode,1293
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B12_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B12_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49353
+valid barcode,36998
+low quality barcode,9270
+invalid barcode,3099
+unparseable barcode,1280
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B1_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B1_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49330
+valid barcode,36821
+low quality barcode,8830
+invalid barcode,3706
+unparseable barcode,1313
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B2_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B2_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48975
+valid barcode,39994
+low quality barcode,8755
+unparseable barcode,1991
+invalid barcode,285
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B3_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B3_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49010
+valid barcode,40549
+low quality barcode,8215
+unparseable barcode,1891
+invalid barcode,335
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B4_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B4_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49049
+valid barcode,40967
+low quality barcode,7808
+unparseable barcode,1913
+invalid barcode,263
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B5_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B5_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49099
+valid barcode,36200
+low quality barcode,8186
+invalid barcode,4820
+unparseable barcode,1695
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B6_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B6_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49362
+valid barcode,31173
+invalid barcode,9700
+low quality barcode,8510
+unparseable barcode,1255
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B7_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B7_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49347
+valid barcode,34835
+low quality barcode,9123
+invalid barcode,5426
+unparseable barcode,1269
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B8_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B8_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49333
+valid barcode,36253
+low quality barcode,8734
+invalid barcode,4426
+unparseable barcode,1254
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/B9_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/B9_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49345
+valid barcode,36983
+low quality barcode,8315
+invalid barcode,4043
+unparseable barcode,1314
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C10_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C10_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49200
+valid barcode,35858
+low quality barcode,8814
+invalid barcode,4696
+unparseable barcode,1432
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C11_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C11_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49262
+valid barcode,36478
+low quality barcode,8742
+invalid barcode,4143
+unparseable barcode,1375
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C12_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C12_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49275
+valid barcode,36395
+low quality barcode,8607
+invalid barcode,4337
+unparseable barcode,1386
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C1_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C1_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49358
+valid barcode,36315
+low quality barcode,9190
+invalid barcode,3900
+unparseable barcode,1237
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C2_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C2_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48975
+valid barcode,41489
+low quality barcode,7332
+unparseable barcode,1928
+invalid barcode,276
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C3_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C3_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48956
+valid barcode,40949
+low quality barcode,7822
+unparseable barcode,1989
+invalid barcode,284
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C4_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C4_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49248
+valid barcode,37179
+low quality barcode,8918
+invalid barcode,3182
+unparseable barcode,1473
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C5_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C5_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48886
+valid barcode,35251
+low quality barcode,8820
+invalid barcode,5300
+unparseable barcode,1743
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C6_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C6_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49370
+valid barcode,36459
+low quality barcode,8107
+invalid barcode,4655
+unparseable barcode,1409
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C7_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C7_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49308
+valid barcode,36520
+low quality barcode,8558
+invalid barcode,4270
+unparseable barcode,1344
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C8_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C8_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49295
+valid barcode,36861
+low quality barcode,8902
+invalid barcode,3507
+unparseable barcode,1435
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/C9_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/C9_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49371
+valid barcode,36701
+low quality barcode,8786
+invalid barcode,3837
+unparseable barcode,1305
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D10_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D10_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49333
+valid barcode,36583
+low quality barcode,8742
+invalid barcode,4091
+unparseable barcode,1251
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D11_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D11_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49393
+valid barcode,36783
+low quality barcode,8903
+invalid barcode,3627
+unparseable barcode,1294
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D12_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D12_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49381
+valid barcode,36453
+low quality barcode,9234
+invalid barcode,3676
+unparseable barcode,1256
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D1_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D1_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49382
+valid barcode,37390
+low quality barcode,8839
+invalid barcode,3122
+unparseable barcode,1267
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D2_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D2_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49035
+valid barcode,41080
+low quality barcode,7627
+unparseable barcode,1941
+invalid barcode,317
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D3_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D3_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48977
+valid barcode,40343
+low quality barcode,8459
+unparseable barcode,1940
+invalid barcode,281
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D4_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D4_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,48991
+valid barcode,35571
+low quality barcode,8990
+invalid barcode,4775
+unparseable barcode,1673
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D5_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D5_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49182
+valid barcode,34627
+low quality barcode,8649
+invalid barcode,6136
+unparseable barcode,1406
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D6_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D6_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49327
+valid barcode,31787
+low quality barcode,9098
+invalid barcode,8566
+unparseable barcode,1222
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D7_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D7_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49342
+valid barcode,35923
+low quality barcode,8372
+invalid barcode,5089
+unparseable barcode,1274
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D8_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D8_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49422
+valid barcode,35599
+low quality barcode,8770
+invalid barcode,4982
+unparseable barcode,1227
+read too short,0
+failed chastity filter,0

--- a/test_example/results/miscellaneous_plates/random_plate_1/D9_fates.csv
+++ b/test_example/results/miscellaneous_plates/random_plate_1/D9_fates.csv
@@ -1,0 +1,8 @@
+fate,count
+invalid outer flank,49386
+valid barcode,36085
+low quality barcode,9040
+invalid barcode,4301
+unparseable barcode,1188
+read too short,0
+failed chastity filter,0


### PR DESCRIPTION
Make the pipeline run OK even if FASTQs are not available if the counts have already been computed (see [here](https://github.com/jbloomlab/seqneut-pipeline/pull/62)). This is designed to make it more portable. Specifically:
  - default `.gitignore` and README now suggest tracking the barcode fates files as well as the counts files, as they are needed by downstream pipeline steps.
  - the invalid barcodes are no longer considered an output of the pipeline as they are not tracked.