### PR TITLE
add mouseover to titer plot to highlight individual sera profiles

### DIFF
--- a/notebooks/aggregate_titers.py
+++ b/notebooks/aggregate_titers.py
@@ -265,6 +265,8 @@ def _(
         bind="legend",
         toggle="true",
         empty=False,
+        on="mouseover",
+        clear="mouseout",
     )
 
     group_selection = alt.selection_point(


### PR DESCRIPTION
This is a suggested minimal change to the visualization of aggregate titer profiles. While the current visualization is really useful for population data, in instances where we have longitudinal samples from the same individuals (or just pre and post vax), both the median plot and the aggregate per-serum titers are not as useful for exploring these data.

Here, I am suggesting adding the ability to scroll over the per-serum titer plot and highlight full profiles. As a profile is highlighted, the sample is also indicated in the legend, so one can see what types of profiles are present relatively rapidly, and understand which samples are linked to specific profile patterns. 