### PR TITLE
record 0 counts if total counts is 0 to avoid division by zero error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### version 6.2.1
 - Set target version for `black` to Python 3.13 in `pyproject.toml`.
+- Fix divide by zero error if no barcode counts ([this pull request](https://github.com/jbloomlab/seqneut-pipeline/pull/85/changes) addressing [this issue](https://github.com/jbloomlab/seqneut-pipeline/issues/83)).
 
 ### version 6.2.0
 Allow one level of nesting in `add_htmls_to_docs`.

--- a/scripts/count_barcodes.py
+++ b/scripts/count_barcodes.py
@@ -62,14 +62,14 @@ valid_barcodes_df = (
 # write valid barcode counts including a 0 count for missing ones
 (
     valid_barcodes_df.sort_values(["count", "barcode"], ascending=[False, True])
-    .assign(fraction_all_valid_and_invalid_counts=lambda x: x["count"] / total_counts)
+    .assign(fraction_all_valid_and_invalid_counts=lambda x: x["count"] / total_counts if total_counts > 0 else 0)
     .to_csv(snakemake.output.counts, index=False, float_format="%.3g")
 )
 
 # process invalid barcodes and find closest valid barcode for each
 invalid_barcodes_df = (
     counts.query("barcode not in @valid_barcodes")
-    .assign(fraction_all_valid_and_invalid_counts=lambda x: x["count"] / total_counts)
+    .assign(fraction_all_valid_and_invalid_counts=lambda x: x["count"] / total_counts if total_counts > 0 else 0)
     .copy()
 )
 

--- a/scripts/count_barcodes.py
+++ b/scripts/count_barcodes.py
@@ -62,14 +62,22 @@ valid_barcodes_df = (
 # write valid barcode counts including a 0 count for missing ones
 (
     valid_barcodes_df.sort_values(["count", "barcode"], ascending=[False, True])
-    .assign(fraction_all_valid_and_invalid_counts=lambda x: x["count"] / total_counts if total_counts > 0 else 0)
+    .assign(
+        fraction_all_valid_and_invalid_counts=lambda x: (
+            x["count"] / total_counts if total_counts > 0 else pd.NA
+        )
+    )
     .to_csv(snakemake.output.counts, index=False, float_format="%.3g")
 )
 
 # process invalid barcodes and find closest valid barcode for each
 invalid_barcodes_df = (
     counts.query("barcode not in @valid_barcodes")
-    .assign(fraction_all_valid_and_invalid_counts=lambda x: x["count"] / total_counts if total_counts > 0 else 0)
+    .assign(
+        fraction_all_valid_and_invalid_counts=lambda x: (
+            x["count"] / total_counts if total_counts > 0 else pd.NA
+        )
+    )
     .copy()
 )
 


### PR DESCRIPTION
This PR applies the fix suggested in #83 which records a `0` for wells with 0 sequenced barcodes, which happens in the rare instance when a well contains no amplified barcodes (usually when the well is inadvertently skipped at various points during library prep).

In the original code, if total counts were 0 this would result in a numpy division by 0 error and pipeline failure. 