### PR TITLE
update software versions including `snakemake`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### version 6.3.0
+- Update package versions (helps fix `snakemake` error when using `nextstrain-prot-titers-tree` by matching versions):
+  + marimo: 0.17.6 -> 0.23
+  + markdown: 3.9 -> 3.10
+  + pillow: 12.0 -> 12.2
+  + ruamel.yaml: 0.18.15 -> 0.19
+  + snakemake: 9.13.2 -> 9.19
+
 #### version 6.2.1
 - Set target version for `black` to Python 3.13 in `pyproject.toml`.
 - Fix divide by zero error if no barcode counts ([this pull request](https://github.com/jbloomlab/seqneut-pipeline/pull/85/changes) addressing [this issue](https://github.com/jbloomlab/seqneut-pipeline/issues/83)).

--- a/environment.yml
+++ b/environment.yml
@@ -8,16 +8,16 @@ dependencies:
   - altair=5.5
   - black
   - mamba
-  - marimo=0.17.6
-  - markdown=3.9
+  - marimo=0.23
+  - markdown=3.10
   - pandas=2.3.3
-  - pillow=12.0
+  - pillow=12.2
   - pip
   - pyarrow
   - python=3.13
-  - ruamel.yaml=0.18.15
+  - ruamel.yaml=0.19
   - snakefmt
-  - snakemake=9.13.2
+  - snakemake=9.19
   - ruff
   - pip:
     - dms_variants==1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "seqneut-pipeline"
-version = "6.2.1"
+version = "6.3.0"
 description = "Modular analysis pipeline for high-throughput sequencing-based neutralization assays"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Update package versions (helps fix `snakemake` error when using `nextstrain-prot-titers-tree` by matching versions):
  + marimo: 0.17.6 -> 0.23
  + markdown: 3.9 -> 3.10
  + pillow: 12.0 -> 12.2
  + ruamel.yaml: 0.18.15 -> 0.19
  + snakemake: 9.13.2 -> 9.19

Becomes version 6.3.0 of `seqneut-pipeline`