### PR TITLE
Build docs even when there are no plates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,25 @@ jobs:
           expected_titers_for_test_collapse_strain_barcodes.csv
           && cd ..
 
+      - name: run pipeline on test example with no plates
+        # in a copy of the test example so the results of the runs above are kept. A
+        # project with no `plates` just counts barcodes for its `miscellaneous_plates`,
+        # and its docs then hold only the HTMLs added with `add_htmls_to_docs` and none of
+        # the sections that describe plates.
+        shell: bash -el {0}
+        run: >
+          cp -a test_example _test_example_no_plates
+          && cd _test_example_no_plates
+          && rm -rf results
+          && snakemake --software-deployment-method conda -j 2
+          --configfile config_no_plates.yml
+          && test -f results/docs/example_html.html
+          && grep -q "Example HTML file" results/docs/index.html
+          && ! grep -q "Titers for all sera" results/docs/index.html
+          && ! grep -q "Per-plate counts and curve fits" results/docs/index.html
+          && ! grep -q "quality control" results/docs/index.html
+          && cd ..
+
       - name: upload results in case of error
         uses: actions/upload-artifact@v7
         if: failure()
@@ -83,4 +102,5 @@ jobs:
           path: |
             test_example/results
             _test_example_collapsed/results
+            _test_example_no_plates/results
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## version 8.1.0
+- Build the docs in `./results/docs` even when there are no `plates`. A project that only counts barcodes for `miscellaneous_plates` previously got no docs at all, which silently ignored any HTML files it added with `add_htmls_to_docs`; those files are now the entire contents of its docs, since every other section describes the plates. This is what lets such a project publish its own analysis of the counts via GitHub Pages.
+
+- Make `plates` an optional configuration key, so that a project with only `miscellaneous_plates` no longer needs a placeholder `plates: {}`. Along with it, `sera_override_defaults` is now optional too (it is keyed by group, and a project with no plates has no groups), and both keys, as well as `miscellaneous_plates`, are accepted as null and not just as an empty dictionary. Note that null is the only way to empty one of these keys from a `--configfile` override, as `snakemake` merges an override into the configuration recursively and so treats an empty dictionary as leaving the existing value untouched.
+
+- Test the no-plates configuration by running the test example a third time with the new `test_example/config_no_plates.yml` overrides, checking that its docs hold the added HTML file and none of the sections describing plates.
+
 ## version 8.0.0
 - Update software versions, most notably `python` to 3.14:
   + `python`: 3.13 -> 3.14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,22 @@ rather than in the rules.
 | `build_docs` | `scripts/build_docs.py` | collects the notebook HTML into `results/docs` |
 | `miscellaneous_plate_count_barcodes` | `scripts/count_barcodes.py` | counting only, for `miscellaneous_plates` |
 
+Every rule above except the last two is defined inside `if plates:`, as it has nothing to
+do without plates. `build_docs` is deliberately outside that block so that a project with
+only `miscellaneous_plates` still gets docs of the HTML it adds with `add_htmls_to_docs`.
+Each of its inputs and params that derives from the plates is therefore guarded with
+`if plates else []`, including the two that are functions: a param function and an input
+function are both evaluated when the job is created, so neither can reach
+`groups_sera_plates()` (which needs the `groups_sera_by_plate` checkpoint) when there are
+no plates. `scripts/build_docs.py` gates the four sections describing the plates on
+`snakemake.params.plates`.
+
+A configuration key that can be empty is read as `config.get(key) or {}` rather than with
+a `get` default, because emptying such a key from a `--configfile` override requires
+setting it to null: `snakemake.utils.update_config` merges an override recursively, so an
+empty dict override leaves the original value untouched. `test_example/config_no_plates.yml`
+relies on this for both `plates` and `sera_override_defaults`.
+
 `funcs.smk` holds the config-processing helpers that run while the rules are being
 defined (`process_plate`, `process_miscellaneous_plates`, `stringify_plate_dates`,
 `get_plate_comparators`, `get_collapse_strain_barcodes`, and the sample-table

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ This dictionary (mapping) contains the heart of the configuration, and may be qu
 Essentially, it specifies what samples are contained in each plate, how those samples should be processed, QC thresholds, and any specific barcodes or samples that should be dropped.
 In addition, each plate is assigned to a *group*, which might be "serum" or "pilot" (if you are mixing analyses of your sera with pilot experiments), or could be additional groups if you have two distinct sets of sera.
 
+This key is optional: leave it out, or set it to null or an empty dictionary (`{}`), for a project that only counts barcodes for the plates specified under `miscellaneous_plates` and so fits no neutralization curves at all.
+Note that `sera_override_defaults` is keyed by group and so must then also be empty, since there are no groups without any plates.
+
 The basic structure is that `plates` maps plate names to configurations for the plates.
 Specifically, it should look like this:
 ```
@@ -540,6 +543,9 @@ The output is that for each plate, the following files are created:
  - `results/miscellaneous_plates/<plate_name>/<well>_invalid.csv`: counts of each invalid barcode in that well of that plate.
  - `results/miscellaneous_plates/<plate_name>/<well>_fates.csv`: summarizing number of reads that are valid and various types of invalid for each well of that plate.
 
+A project can consist of nothing but miscellaneous plates, by leaving `plates` empty.
+The docs in `./results/docs` are still built in that case, holding whatever HTML files you add with `add_htmls_to_docs` (see the GitHub Pages section below), which is how to include your own analysis of these counts alongside them.
+
 
 ## Results of running the pipeline
 The results of running the pipeline are put in the `./results/` subdirectory of your main repo.
@@ -623,6 +629,8 @@ add_htmls_to_docs = {
 ```
 
 You can have one level of nesting in these docs to allow subheadings.
+
+These files are added to the docs even for a project with no `plates`, in which case the docs contain only them, as the other sections all describe the plates.
 
 ## Test example and testing via GitHub Actions
 The [./test_example](test_example) subdirectory contains a small test example that illustrates use of the pipeline.

--- a/funcs.smk
+++ b/funcs.smk
@@ -19,7 +19,8 @@ def stringify_plate_dates(config):
 
     """
     for config_key in ["plates", "miscellaneous_plates"]:
-        for plate_d in config.get(config_key, {}).values():
+        # `or {}` rather than a `get` default, as either key can be present but null
+        for plate_d in (config.get(config_key) or {}).values():
             if "date" in plate_d:
                 plate_d["date"] = str(plate_d["date"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "seqneut-pipeline"
-version = "8.0.0"
+version = "8.1.0"
 description = "Modular analysis pipeline for high-throughput sequencing-based neutralization assays"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -53,63 +53,68 @@ md_text = [
     # table of contents: https://python-markdown.github.io/extensions/toc/
     "[TOC]",
     "",
-    "## Titers for all sera",
-]
-for group in group_order:
-    md_text.append(
-        f"- [Interactive chart of titers (`{group}`)]"
-        f"({os.path.basename(copied_files[titers_charts_by_group[group]])})"
-    )
-md_text += [
-    "",
-    "## Per-serum neutralization titers",
 ]
 
-assert len(snakemake.params.groups_sera) == len(snakemake.input.serum_titers_htmls)
-for group in group_order:
-    md_text.append(f"\n### {group}")
-    for serum in groups[group]:
-        f = snakemake.input.serum_titers_htmls[
-            snakemake.params.groups_sera.index((group, serum))
-        ]
-        md_text.append(f"- [{serum}]({os.path.basename(copied_files[f])})")
-
-md_text += ["", "## Per-plate counts and curve fits"]
-assert len(snakemake.params.plates) == len(snakemake.input.process_plates_htmls)
-for group in group_order:
-    md_text.append(f"\n### {group}")
-    for plate in [p for (p, g) in snakemake.params.plates.items() if g == group]:
-        f = snakemake.input.process_plates_htmls[
-            list(snakemake.params.plates).index(plate)
-        ]
-        md_text.append(f"- [{plate}]({os.path.basename(copied_files[f])})")
-
-if plate_corr_htmls_by_plate:
+# Everything below describes the plates, and so is omitted for a project that has no
+# `plates` and only counts barcodes for `miscellaneous_plates`. Such a project still gets
+# the `add_htmls_to_docs` sections at the end of this script.
+if snakemake.params.plates:
+    md_text.append("## Titers for all sera")
+    for group in group_order:
+        md_text.append(
+            f"- [Interactive chart of titers (`{group}`)]"
+            f"({os.path.basename(copied_files[titers_charts_by_group[group]])})"
+        )
     md_text += [
         "",
-        (
-            "## Plate-to-plate correlations of titers "
-            "(only for plates that share sera with other plates)"
-        ),
+        "## Per-serum neutralization titers",
     ]
+
+    assert len(snakemake.params.groups_sera) == len(snakemake.input.serum_titers_htmls)
     for group in group_order:
-        group_corr_plates = [
-            plate
-            for (plate, plate_group) in snakemake.params.corr_plates.items()
-            if plate_group == group
-        ]
-        if not group_corr_plates:
-            continue
         md_text.append(f"\n### {group}")
-        for plate in group_corr_plates:
-            f = plate_corr_htmls_by_plate[plate]
+        for serum in groups[group]:
+            f = snakemake.input.serum_titers_htmls[
+                snakemake.params.groups_sera.index((group, serum))
+            ]
+            md_text.append(f"- [{serum}]({os.path.basename(copied_files[f])})")
+
+    md_text += ["", "## Per-plate counts and curve fits"]
+    assert len(snakemake.params.plates) == len(snakemake.input.process_plates_htmls)
+    for group in group_order:
+        md_text.append(f"\n### {group}")
+        for plate in [p for (p, g) in snakemake.params.plates.items() if g == group]:
+            f = snakemake.input.process_plates_htmls[
+                list(snakemake.params.plates).index(plate)
+            ]
             md_text.append(f"- [{plate}]({os.path.basename(copied_files[f])})")
 
-md_text += [
-    "",
-    "## Summary of data dropped during quality control",
-    f"[Notebook summarizing QC drops]({os.path.basename(copied_files[snakemake.input.qc_drops_html])})",
-]
+    if plate_corr_htmls_by_plate:
+        md_text += [
+            "",
+            (
+                "## Plate-to-plate correlations of titers "
+                "(only for plates that share sera with other plates)"
+            ),
+        ]
+        for group in group_order:
+            group_corr_plates = [
+                plate
+                for (plate, plate_group) in snakemake.params.corr_plates.items()
+                if plate_group == group
+            ]
+            if not group_corr_plates:
+                continue
+            md_text.append(f"\n### {group}")
+            for plate in group_corr_plates:
+                f = plate_corr_htmls_by_plate[plate]
+                md_text.append(f"- [{plate}]({os.path.basename(copied_files[f])})")
+
+    md_text += [
+        "",
+        "## Summary of data dropped during quality control",
+        f"[Notebook summarizing QC drops]({os.path.basename(copied_files[snakemake.input.qc_drops_html])})",
+    ]
 
 for heading, heading_d in snakemake.params.add_htmls_to_docs.items():
     md_text += ["", f"## {heading}"]

--- a/seqneut-pipeline.smk
+++ b/seqneut-pipeline.smk
@@ -41,9 +41,11 @@ stringify_plate_dates(config)  # so `snakemake` can JSON serialize the config
 # before the plates are processed, as their validation depends on it
 collapse_strain_barcodes = get_collapse_strain_barcodes(config)
 
+# `plates` may be absent, null, or empty for a project that only has
+# `miscellaneous_plates`, and so just counts barcodes rather than fitting any curves
 plates = {
     str(plate): process_plate(str(plate), plate_params)
-    for (plate, plate_params) in config["plates"].items()
+    for (plate, plate_params) in (config.get("plates") or {}).items()
 }
 
 groups = sorted(set(plate_params["group"] for plate_params in plates.values()))
@@ -88,8 +90,11 @@ wildcard_constraints:
     group="|".join(groups),
 
 
-if not set(config["sera_override_defaults"]).issubset(groups):
-    raise ValueError(f"{config['sera_override_defaults']=} keyed by invalid groups")
+# like `plates`, may be absent or null, both of which mean no sera override the defaults
+sera_override_defaults = config.get("sera_override_defaults") or {}
+
+if not set(sera_override_defaults).issubset(groups):
+    raise ValueError(f"{sera_override_defaults=} keyed by invalid groups")
 
 
 if plates == {}:
@@ -103,10 +108,9 @@ else:
     samples = samples.set_index("sample").to_dict(orient="index")
 
 
-if "miscellaneous_plates" in config:
-    miscellaneous_plates = process_miscellaneous_plates(config["miscellaneous_plates"])
-else:
-    miscellaneous_plates = {}
+miscellaneous_plates = process_miscellaneous_plates(
+    config.get("miscellaneous_plates") or {}
+)
 
 # define `add_htmls_to_docs` if not already defined.
 try:
@@ -244,26 +248,20 @@ if plates:
             ),
             concentration_units=lambda wc: group_concentration_units[wc.group],
             serum_titer_as=lambda wc: (
-                config["sera_override_defaults"][wc.group][wc.serum]["titer_as"]
+                sera_override_defaults[wc.group][wc.serum]["titer_as"]
                 if (
-                    (wc.group in config["sera_override_defaults"])
-                    and (wc.serum in config["sera_override_defaults"][wc.group])
-                    and (
-                        "titer_as"
-                        in config["sera_override_defaults"][wc.group][wc.serum]
-                    )
+                    (wc.group in sera_override_defaults)
+                    and (wc.serum in sera_override_defaults[wc.group])
+                    and ("titer_as" in sera_override_defaults[wc.group][wc.serum])
                 )
                 else config["default_serum_titer_as"]
             ),
             qc_thresholds=lambda wc: (
-                config["sera_override_defaults"][wc.group][wc.serum]["qc_thresholds"]
+                sera_override_defaults[wc.group][wc.serum]["qc_thresholds"]
                 if (
-                    (wc.group in config["sera_override_defaults"])
-                    and (wc.serum in config["sera_override_defaults"][wc.group])
-                    and (
-                        "qc_thresholds"
-                        in config["sera_override_defaults"][wc.group][wc.serum]
-                    )
+                    (wc.group in sera_override_defaults)
+                    and (wc.serum in sera_override_defaults[wc.group])
+                    and ("qc_thresholds" in sera_override_defaults[wc.group][wc.serum])
                 )
                 else config["default_serum_qc_thresholds"]
             ),
@@ -384,57 +382,6 @@ if plates:
         script:
             "scripts/run_marimo_w_context_pickle.py"
 
-    rule build_docs:
-        """Build the HTML documentation."""
-        input:
-            lambda wc: [
-                f
-                for d in add_htmls_to_docs.values()
-                for v in d.values()
-                for f in (v.values() if isinstance(v, dict) else [v])
-            ],
-            titers_charts=rules.aggregate_titers.output.titers_charts,
-            serum_titers_htmls=lambda wc: [
-                f"results/sera/{group}_{serum}/{group}_{serum}_titers.html"
-                for (group, serum) in groups_sera_plates()
-            ],
-            process_plates_htmls=expand(
-                "results/plates/{plate}/process_{plate}.html",
-                plate=plates,
-            ),
-            plate_corr_htmls=[
-                rules.plate_to_plate_corr.output.marimo_html.format(
-                    group=group, plate=plate
-                )
-                for (plate, group) in corr_plates.items()
-            ],
-            qc_drops_html="results/qc_drops/aggregate_qc_drops.html",
-        output:
-            docs=directory("results/docs"),
-        log:
-            "results/logs/build_docs.txt",
-        conda:
-            "environment.yml"
-        params:
-            description=config["description"],
-            groups_sera=lambda wc: list(groups_sera_plates()),
-            plates={plate: plates[plate]["group"] for plate in plates},
-            # keyed by plate in the same order as `plate_corr_htmls`
-            corr_plates=corr_plates,
-            add_htmls_to_docs=lambda wc: {
-                key: {
-                    key2: (
-                        {k3: str(v3) for k3, v3 in val2.items()}
-                        if isinstance(val2, dict)
-                        else str(val2)
-                    )
-                    for (key2, val2) in val.items()
-                }
-                for (key, val) in add_htmls_to_docs.items()
-            },
-        script:
-            "scripts/build_docs.py"
-
 
 rule miscellaneous_plate_count_barcodes:
     """Count barcodes for a well in a miscellaneous plate."""
@@ -466,33 +413,93 @@ rule miscellaneous_plate_count_barcodes:
         "scripts/count_barcodes.py"
 
 
-if plates:
-    seqneut_pipeline_outputs = [
-        rules.aggregate_titers.output.titers,
-        rules.aggregate_titers.output.pickles,
-        rules.aggregate_qc_drops.output.plate_qc_drops,
-        rules.aggregate_qc_drops.output.barcode_qc_drops,
-        rules.aggregate_qc_drops.output.groups_sera_qc_drops,
-        *[
-            rules.plate_to_plate_corr.output.corrs_csv.format(group=group, plate=plate)
+rule build_docs:
+    """Build the HTML documentation.
+
+    Defined outside the `if plates` block above so that a project with only
+    `miscellaneous_plates` still gets docs of the HTMLs it adds with
+    `add_htmls_to_docs`. Everything derived from the plates is then empty, and
+    `scripts/build_docs.py` omits the sections that describe them.
+
+    """
+    input:
+        lambda wc: [
+            f
+            for d in add_htmls_to_docs.values()
+            for v in d.values()
+            for f in (v.values() if isinstance(v, dict) else [v])
+        ],
+        titers_charts=(rules.aggregate_titers.output.titers_charts if plates else []),
+        serum_titers_htmls=lambda wc: (
+            [
+                f"results/sera/{group}_{serum}/{group}_{serum}_titers.html"
+                for (group, serum) in groups_sera_plates()
+            ]
+            if plates
+            else []
+        ),
+        process_plates_htmls=expand(
+            "results/plates/{plate}/process_{plate}.html",
+            plate=plates,
+        ),
+        plate_corr_htmls=[
+            rules.plate_to_plate_corr.output.marimo_html.format(
+                group=group, plate=plate
+            )
             for (plate, group) in corr_plates.items()
         ],
-        # the notebook HTMLs are not listed here, as they are inputs to `build_docs`
-        rules.build_docs.output.docs,
-        *[
-            f"results/miscellaneous_plates/{plate}/{well}_{suffix}"
-            for plate in miscellaneous_plates
-            for well in miscellaneous_plates[plate]["wells"]
-            for suffix in ["counts.csv", "fates.csv"]
-        ],
-    ]
+        qc_drops_html=(rules.aggregate_qc_drops.output.marimo_html if plates else []),
+    output:
+        docs=directory("results/docs"),
+    log:
+        "results/logs/build_docs.txt",
+    conda:
+        "environment.yml"
+    params:
+        description=config["description"],
+        groups_sera=lambda wc: (list(groups_sera_plates()) if plates else []),
+        plates={plate: plates[plate]["group"] for plate in plates},
+        # keyed by plate in the same order as `plate_corr_htmls`
+        corr_plates=corr_plates,
+        add_htmls_to_docs=lambda wc: {
+            key: {
+                key2: (
+                    {k3: str(v3) for k3, v3 in val2.items()}
+                    if isinstance(val2, dict)
+                    else str(val2)
+                )
+                for (key2, val2) in val.items()
+            }
+            for (key, val) in add_htmls_to_docs.items()
+        },
+    script:
+        "scripts/build_docs.py"
 
-else:
-    seqneut_pipeline_outputs = [
-        *[
-            f"results/miscellaneous_plates/{plate}/{well}_{suffix}"
-            for plate in miscellaneous_plates
-            for well in miscellaneous_plates[plate]["wells"]
-            for suffix in ["counts.csv", "fates.csv"]
-        ],
-    ]
+
+seqneut_pipeline_outputs = [
+    *(
+        [
+            rules.aggregate_titers.output.titers,
+            rules.aggregate_titers.output.pickles,
+            rules.aggregate_qc_drops.output.plate_qc_drops,
+            rules.aggregate_qc_drops.output.barcode_qc_drops,
+            rules.aggregate_qc_drops.output.groups_sera_qc_drops,
+            *[
+                rules.plate_to_plate_corr.output.corrs_csv.format(
+                    group=group, plate=plate
+                )
+                for (plate, group) in corr_plates.items()
+            ],
+        ]
+        if plates
+        else []
+    ),
+    *[
+        f"results/miscellaneous_plates/{plate}/{well}_{suffix}"
+        for plate in miscellaneous_plates
+        for well in miscellaneous_plates[plate]["wells"]
+        for suffix in ["counts.csv", "fates.csv"]
+    ],
+    # the notebook HTMLs are not listed here, as they are inputs to `build_docs`
+    rules.build_docs.output.docs,
+]

--- a/test_example/config_no_plates.yml
+++ b/test_example/config_no_plates.yml
@@ -1,0 +1,20 @@
+# === Configuration overrides to test a project with no `plates` =======================
+
+# Add this file to the configuration to run the test example with no `plates`, as a
+# project that only counts barcodes for `miscellaneous_plates` would have:
+#
+#   snakemake -j <n_jobs> --software-deployment-method conda \
+#       --configfile config_no_plates.yml
+#
+# The pipeline then just counts barcodes for the miscellaneous plates and builds docs of
+# the HTMLs added by `add_htmls_to_docs`, with no curve fitting, titers, or QC.
+
+# Both keys are set to null rather than to an empty dict, because `snakemake` merges a
+# configuration override into the configuration recursively: an empty dict leaves the
+# value from `config.yml` untouched, whereas null overwrites it.
+
+plates:
+
+# `sera_override_defaults` is keyed by group, and there are no groups without any plates,
+# so the overrides inherited from `config.yml` have to be cleared as well.
+sera_override_defaults:


### PR DESCRIPTION
Move `rule build_docs` out of the `if plates:` block in `seqneut-pipeline.smk`, so that a project with only `miscellaneous_plates` gets docs of the HTML it adds with `add_htmls_to_docs`. Previously that dict was silently ignored by such a project, as `build_docs` was never defined for it.

Each of the rule's inputs and params that derives from the plates is guarded with `if plates else []`. This includes the two that are functions, `serum_titers_htmls` and `params.groups_sera`: both are evaluated when the job is created, so either would otherwise call `groups_sera_plates()` and fail on the `groups_sera_by_plate` checkpoint that does not exist without plates. `qc_drops_html` also now refers to `rules.aggregate_qc_drops.output.marimo_html` rather than repeating that path. `process_plates_htmls` and `plate_corr_htmls` already degrade to empty lists, as they expand over `plates` and `corr_plates`.

`scripts/build_docs.py` gates its four plate sections (titers, per-serum, per-plate, and QC drops) on `snakemake.params.plates`; the QC drops section is what would otherwise fail, as it indexes `copied_files` with the now-empty `input.qc_drops_html`.

`seqneut_pipeline_outputs` becomes one list rather than an if/else on `plates`, which lists the miscellaneous-plate files once instead of in both branches and makes `build_docs.output.docs` unconditional, still after the numerical results.

Make `plates` and `sera_override_defaults` optional, both read as `config.get(key) or {}`. A project with only miscellaneous plates then needs no placeholder `plates: {}`, and, more to the point, the keys can be emptied from a `--configfile` override: `update_config` merges an override recursively, so `plates: {}` there leaves the existing plates untouched and only null overwrites them. `sera_override_defaults` has to go too, as it is keyed by group and the existing `issubset(groups)` check rejects any key once there are no groups. Its three uses in `group_serum_titers` now read the normalized local.

`stringify_plate_dates` in `funcs.smk` used `config.get(key, {})`, which raises on a key that is present but null, so it also becomes `or {}`. That fixes a null `miscellaneous_plates:` as well, which was already broken before this change.

Add `test_example/config_no_plates.yml` and a third test-example run in the GitHub Action that checks the resulting docs hold the added HTML file and none of the plate sections.