### PR TITLE
add `tree-annotated-plot` to conda env (becomes 9.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### version 9.1.0
+- Add [tree-annotated-plot](https://github.com/jbloomlab/tree-annotated-plot) to the `seqneut-pipeline` conda environment.
+
 ## version 9.0.0
 - Correctly record the QC filter that dropped a barcode in `./results/plates/{plate}/qc_drops.yml`. Every barcode-level drop was previously labeled `min_neut_standard_frac_per_well`, naming a filter it had not failed. Only the recorded reason changes, so no titers change.
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,4 @@ dependencies:
   - pip:
     - dms_variants==1.6.0
     - neutcurve==2.4.0
-    - tree-annotated-plot==0.3.0
+    - tree-annotated-plot==0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - pip:
     - dms_variants==1.6.0
     - neutcurve==2.4.0
+    - tree-annotated-plot==0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "seqneut-pipeline"
-version = "9.0.0"
+version = "9.1.0"
 description = "Modular analysis pipeline for high-throughput sequencing-based neutralization assays"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Adds [`tree-annotated-plot`](https://github.com/jbloomlab/tree-annotated-plot) to the
`seqneut-pipeline` conda environment, pinned at `0.4.0`, so projects using this
environment can draw a phylogenetic tree alongside a chart's strain axis.

Nothing in the pipeline itself imports it yet; this only makes it available to project
code that shares the environment. First consumer is the titer summary plots in
[flu-seqneut-2026](https://github.com/jbloomlab/flu-seqneut-2026).

0.4.0 rather than 0.3.0 because it fixes the strain labels running up against the chart's
frame when `connect_leader_to_label` is on, and adds a `spacing` parameter for the gap
between the tree and chart panels
([release notes](https://github.com/jbloomlab/tree-annotated-plot/releases/tag/v0.4.0)).

Version becomes 9.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
