### PR TITLE
Add optional `viral_library_validations` for checking viral libraries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,15 @@ jobs:
         shell: bash -el {0}
         run: cd test_example && python test_titers_as_expected.py && cd ..
 
+      - name: test the viral libraries were validated
+        shell: bash -el {0}
+        run: >
+          cd test_example
+          && test -f results/validate_viral_library/H3N2_lib2023_Kikawa_validation.txt
+          && grep -q "110 barcodes for 36 strains"
+          results/validate_viral_library/pdmH1N1_lib2023_loes_validation.txt
+          && cd ..
+
       - name: run pipeline on test example collapsing strain barcodes
         # in a copy of the test example so the results of the run above are kept
         shell: bash -el {0}
@@ -94,6 +103,27 @@ jobs:
           && ! grep -q "quality control" results/docs/index.html
           && cd ..
 
+      - name: run pipeline on test example with a viral library that fails validation
+        # `viral_library_validations` exists to stop a run on a library that does not meet
+        # it, so the failure is tested as well as the success. Just the one validation is
+        # requested, with one job, so that which log the run leaves behind does not depend
+        # on the order `snakemake` happens to schedule jobs in. The assertion is on the
+        # log, as `snakemake` deletes a failed job's output but keeps its log.
+        shell: bash -el {0}
+        run: >
+          cp -a test_example _test_example_bad_viral_library
+          && cd _test_example_bad_viral_library
+          && rm -rf results
+          && ! snakemake --software-deployment-method conda -j 1
+          --configfile config_bad_viral_library.yml
+          -- results/validate_viral_library/pdmH1N1_lib2023_loes_validation.txt
+          && ! test -f results/validate_viral_library/pdmH1N1_lib2023_loes_validation.txt
+          && grep -q "FAIL  .barcode. matches"
+          results/logs/validate_viral_library_pdmH1N1_lib2023_loes.txt
+          && grep -q "OK   .strain. matches"
+          results/logs/validate_viral_library_pdmH1N1_lib2023_loes.txt
+          && cd ..
+
       - name: upload results in case of error
         uses: actions/upload-artifact@v7
         if: failure()
@@ -103,4 +133,5 @@ jobs:
             test_example/results
             _test_example_collapsed/results
             _test_example_no_plates/results
+            _test_example_bad_viral_library/results
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+### version 9.2.0
+- Added an optional `viral_library_validations` key that checks each CSV in `viral_libraries` against expectations declared in the config and writes a report to `./results/validate_viral_library/{viral_library}_validation.txt`. Added because most projects had their own version of this rule, which is better modularized in the pipeline. A project with a local copy has to delete it in the same commit that bumps this submodule, as `snakemake` will not parse two rules of the same name.
+
+- Updated `.gitignore` to track viral validation output.
+
+- Added `biopython` (version 1.88) to `environment.yml`.
+
 ### version 9.1.0
 - Add [tree-annotated-plot](https://github.com/jbloomlab/tree-annotated-plot) to the `seqneut-pipeline` conda environment.
 

--- a/README.md
+++ b/README.md
@@ -9,38 +9,38 @@
 
 ---
 
-This is a modular analysis pipeline for analyzing high-throughput sequencing-based neutralization assays of the type developed in the [Bloom lab](https://jbloomlab.org).
+This is a modular pipeline for analyzing high-throughput sequencing-based neutralization assays developed in the [Bloom lab](https://jbloomlab.org).
 
 Please cite [Loes et al (2024)](https://doi.org/10.1128/jvi.00689-24) if you use this pipeline for your scientific study.
 
 Here are some key studies using this pipeline:
+  - [Kikawa et al (2026), Virus Evolution](https://doi.org/10.1093/ve/veag046)
   - [Loes et al (2026), Journal of Virology](https://doi.org/10.1128/jvi.00317-26)
-  - [Kikawa et al (2026), bioRxiv](https://doi.org/10.64898/2026.02.18.706711)
   - [Kikawa et al (2025), Virus Evolution](https://doi.org/10.1093/ve/veaf086)
   - [Kikawa et al (2026), eLife](https://doi.org/10.7554/eLife.106811)
   - [Loes et al (2024), Journal of Virology](https://doi.org/10.1128/jvi.00689-24)
 
-For an up-to-date example of use of this pipeline for a real project, see [https://github.com/jbloomlab/flu-seqneut-2025to2026](https://github.com/jbloomlab/flu-seqneut-2025to2026).
+For up-to-date examples of use of this pipeline for real projects, see:
+  - [https://github.com/jbloomlab/flu-seqneut-2026](https://github.com/jbloomlab/flu-seqneut-2026).
 
 See [here](https://github.com/jbloomlab/seqneut-pipeline/graphs/contributors) for a list of the contributors to this pipeline.
 
 ## Overview
 
 This pipeline goes from the FASTQ files that represent the counts of each barcoded viral variant to the computed neutralization titers for each sera.
-The titers are computed by fitting Hill-curve style neutralization curves using the [neutcurve](https://jbloomlab.github.io/neutcurve/) package; see the documentation for the details of these curves.
-The titers represent the reciprocal serum dilutions at which half the viral infectivity is neutralized.
+The titers are computed by fitting Hill-curve style neutralization curves using the [neutcurve](https://jbloomlab.github.io/neutcurve/) package.
+The titers represent the reciprocal serum dilutions or antibody concentrations at which half the viral infectivity is neutralized.
 The pipeline provides options to compute these titers as either:
  - the reciprocal of the inhibitory concentration 50% (IC50), namely as the neutralization titer 50% (NT50)
  - the reciprocal of the midpoint of the neutralization curve
 
 When the curves are fit with a top plateau of 1 and a bottom plateau of zero, these two different ways of calculating the titers are identical, and represent the serum dilution factor at which the serum neutralizes half of the viral infectivity.
-Typically there will be multiple replicates, and the final reported titer is the median among replicates.
+There can be multiple experimental replicates for each titer measurement, and the final reported titer is the median among replicates.
 
 The pipeline also performs extensive quality control at different steps using configurable options described below.
 
 ## Using this pipeline
 This pipeline is designed to be included as a modular portion of a larger [snakemake](https://snakemake.readthedocs.io/) analysis.
-This pipeline processes FASTQ files to get the counts of each barcode, analyzes those to determine the fraction infectivity at each serum concentration, and then fits and plots neutralization curves.
 
 To use the pipeline, first create another repository specific to your project.
 The include this pipeline as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) in your repository, where it will be present in a subdirectory named `seqneut-pipeline`.
@@ -85,17 +85,17 @@ rule all:
 ```
 
 In this `Snakefile`, the `seqneut_pipeline_outputs` specify files created by the pipeline.
-Several of of these may be of special interest for you to use in additional rules you define in `Snakefile`:
+Several of of these may be of special interest to use in additional rules you define in `Snakefile`:
   - `./results/aggregated_titers/titers_{group}.csv`: CSV with the final (median across replicates) titers for each serum-virus pair in a group after applying quality control filters.
   - `./results/aggregated_titers/curvefits_{group}.pickle`: a pickled [neutcurve.CurveFits](https://jbloomlab.github.io/neutcurve/neutcurve.curvefits.html#neutcurve.curvefits.CurveFits) object with all of the curve fits for all serum-virus-replicates in a group after applying the QC filters. You can use the methods of this object to make plots of neutralization curves for specific sera / viruses / replicates.
 
 In addition, you need to create the configuration file `config.yml` and ensure it includes the appropriate configuration for `seqneut-pipeline` as described below.
 
-To track the correct files in the created results, we suggest you copy the [./test_example/.gitignore](test_example/.gitignore) file to be the `.gitignore` for your main repo.
-This will track key results files, but not an excessive number of non-essential files.
+To track the correct files in the created results, copy the [./test_example/.gitignore](test_example/.gitignore) file to be the `.gitignore` for your main repo.
+This will track key results files, but not all of the files created in `./results/`.
 
 Finally, you need to create a `conda` environment that minimally includes the packages needed to run the pipeline, which are a recent version of [snakemake](https://snakemake.readthedocs.io/) and [pandas](https://pandas.pydata.org/).
-You can either create your own environment containing these, or simply build and use the one specified in [environment.yml](environment.yml) file of `seqneut-pipeline`, which is named `seqneut-pipeline`. So if you are using that environment, you can simply run the pipeline with:
+You can either create your own environment, but we suggest you use the one specified in [environment.yml](environment.yml) file of `seqneut-pipeline`, which is named `seqneut-pipeline`. If you are using that environment, you can simply run the pipeline with:
 ```
 conda activate seqneut-pipeline
 snakemake -j <n_jobs> --software-deployment-method conda
@@ -105,7 +105,7 @@ snakemake -j <n_jobs> --software-deployment-method conda
 The configuration for the pipeline is in a file called `config.yml`.
 An example configuration file is in [./test_example/config.yml](test_example/config.yml) (although some of the QC thresholds are set more leniently to make the test example work for small data as described in the comments in that YAML).
 
-Here we describe the required keys in this YAML file (you can also add additional information specific to your repo, but we advise adding comments to put that in a separate part of the YAML from the `seqneut-pipeline` configuration).
+Here we describe the required keys in this YAML file (you can also add additional information specific to your repo, but we advise adding comments in the YAML to separate project-specific and `seqneut-pipeline` configuration).
 For background on YAML format, including on the anchor (`&`) and merge (`<<: *`) operators that can be helpful to simplify the YAML file, see [here](https://spacelift.io/blog/yaml) and [here](https://ktomk.github.io/writing/yaml-anchor-alias-and-merge-key.html).
 
 The top-level keys in the YAML are:
@@ -120,7 +120,7 @@ This will almost always be a subdirectory of the same name, so this key will be 
 Description of pipeline, used in the HTML docs rendering.
 Should include title (with markdown `#` heading, authors and/or citation, and link to GitHub repo.
 For instance:
-```
+```yaml
 description: |
   # <title>
   <short description>
@@ -131,24 +131,94 @@ description: |
 ```
 
 ### viral_libraries
-A dictionary (mapping) of viral library names to CSV files holding these libraries.
-So in general this key will look like:
-```
+A dictionary (mapping) of viral library names to CSV files holding these libraries, as in:
+```yaml
 viral_libraries:
   pdmH1N1_lib2023_loes: data/viral_libraries/pdmH1N1_lib2023_loes.csv
   <potentially more viral libraries specified as name: CSV pairs>
 ```
-The recommended way to organize the viral libraries (as indicated above) is to put them in a `./data/viral_libraries/` subdirectory.
+The recommended way to organize the viral libraries is to put them in a `./data/viral_libraries/` subdirectory.
 
-The CSV files themselves will have columns specifying the viral barcode and the strain it corresponds to, such as:
-```
+The CSV files themselves must have columns specifying the viral barcode and the strain it corresponds to, such as:
+```csv
 barcode,strain
 ACGGAATCCCCTGAGA,A/Washington/23/2020
 GCATGGATCCTTTACT,A/Togo/845/2020
 <additional lines>
 ```
-These CSV files can optionally have additional columns as well if those are useful for storing further metadata.
 The *barcode* cannot contain whitespace, nor can the *strain* if using `collapse_strain_barcodes`.
+These CSV files can optionally have additional columns that store further metadata;
+use the optional `viral_library_validations` described next to specify what any further columns must hold.
+
+### viral_library_validations
+An optional key giving checks to apply to each CSV in `viral_libraries`, keyed by library name.
+If absent or null then no library is validated; if present it must have an entry for every library.
+A library that fails any of its checks stops the run, and a report of every library is written to `./results/validate_viral_library/{viral_library}_validation.txt`.
+
+Each library's entry has a `columns` mapping with one entry per column to check.
+Only `barcode` and `strain` have to be listed, but we recommend you include any other important columns in your libraries CSV.
+A minimal entry looks like:
+```yaml
+viral_library_validations:
+  pdmH1N1_lib2023_loes:
+    columns:
+      barcode: {nulls: false, unique: barcode, matches: ['^[ACGT]{16}$']}
+      strain: {nulls: false, matches: ['^\S+$']}
+```
+Where several libraries share their checks, write the entry once and give it a YAML anchor, as [./test_example/config.yml](test_example/config.yml) does.
+
+A column entry may have the following keys, of which only `nulls` is required:
+
+  - `nulls`: whether the column may be empty.
+  - `unique`: `barcode` if the value must be distinct for every barcode (row), or `strain` if it must be distinct for every strain. Nulls are ignored (use the `nulls` option to specify if those are allowed).
+  - `unique_within`: names another column scoping `unique: strain`, so a value must only be unique within this group of the library.
+  - `values`: list of values the column may hold, where it is categorical.
+  - `matches`: regular expressions the value must match.
+  - `length`: `{min, max}`, the range of lengths the value may have.
+  - `translates_to`: names the column holding the protein this coding sequence translates to.
+  - `numeric`: whether the value must be a number.
+  - `non_null_when`: `{column: value}`, the column must be set for exactly the rows where that column holds this value, and so must be empty in all the others.
+  - `by` and `groups`: `matches` and `length` applied per value of another column, for a convention that differs between the groups of strains in a library. `by` names that column, which must declare `values`, and `groups` must have an entry for each of them.
+
+A libraries CSV can also have columns not specified for validation, but we recommend you validate any important columns used by custom rules in the pipeline or that provide important metadata you want to validate is present.
+
+Note that regular expressions are best written in single quotes, as a backslash in a double-quoted YAML string is an escape (so `"^\S+$"` is an error, while `'^\S+$'` is what you want).
+
+Here is a more complex example, for a library of influenza HA ectodomains of two subtypes with a *designed* and an *actual* version that share their checks:
+```yaml
+viral_library_validations:
+  DRIVElib: &library_validations
+    columns:
+      strain: {nulls: false, matches: ['^\S+$']}
+      barcode: {nulls: false, unique: barcode, matches: ['^[ACGT]{16}$']}
+      alternative_names: {nulls: true}  # empty when the strain has no other name
+      subtype: {nulls: false, values: [H1N1, H3N2]}
+      # "True" / "False" quoted, as the CSV is read as text and so values are compared as written
+      vaccine_strain: {nulls: false, values: ["True", "False"]}
+      clade: {nulls: false}
+      subclade: {nulls: false}
+      # the subtypes share haplotype names, so a haplotype names one strain only within one
+      derived_haplotype: {nulls: false, unique: strain, unique_within: subtype}
+      collection_date: {nulls: false, numeric: true}
+      nt_sequence_HA_ectodomain:
+        nulls: false
+        unique: strain
+        matches: ['^([ACGT]{3})+$']
+        translates_to: protein_sequence_HA_ectodomain
+      protein_sequence_HA_ectodomain:
+        nulls: false
+        unique: strain
+        matches: ['^[ACDEFGHIKLMNPQRSTVWY]+$']  # no ambiguities and no stop codons
+        by: subtype  # the ectodomain length and termini differ between the subtypes
+        groups:
+          H1N1:
+            length: {min: 500, max: 500}
+            matches: ['^CIGY', '[EK]IDGV$']
+          H3N2:
+            length: {min: 501, max: 501}
+            matches: ['^Q[KEN][IL]P', 'NNRFQ$']
+  DRIVElib-designed: *library_validations
+```
 
 ### collapse_strain_barcodes
 An optional key that determines whether each of a strain's barcodes is analyzed as its own measurement of that strain (the default), or whether they are all collapsed into a single measurement.
@@ -158,7 +228,7 @@ The rationale for collapsing barcodes is that the noise in the measurements is l
 Which rationale wins out can be experiment-dependent, depending for instance on the evenness of the barcode distribution and the number of strains and barcodes in the library, so we do not have a universal recommendation on whether collapsing is or is not a good idea.
 
 Set it as below to sum the counts of all of a strain's barcodes in each well before any of the QC or curve fitting, so that there is one neutralization curve per strain on a plate rather than one per barcode:
-```
+```yaml
 collapse_strain_barcodes: true
 ```
 If the key is not specified it defaults to `false`.
@@ -177,12 +247,12 @@ Optional: a CSV with a column named "strain" that lists the strains in the order
 If not specified or set to "null", then plotting is just alphabetical.
 Must include all strains being used if specified.
 So should look like this:
-```
+```yaml
 viral_strain_plot_order: data/viral_strain_plot_order.csv
 ```
 
 The CSV file itself will just have a column named "strain" specifying the order, such as:
-```
+```csv
 strain
 A/California/07/2009
 A/Michigan/45/2015
@@ -192,7 +262,7 @@ A/Michigan/45/2015
 ### curve_display_method
 How large panels of neutralization curves are displayed in the HTML reports created by the pipeline and rendered in the documentation.
 Set such as:
-```
+```yaml
 curve_display_method: svg
 ```
 
@@ -205,7 +275,7 @@ Options are:
 ### neut_standard_sets
 A dictionary (mapping) of neutralization-standard set names to CSV files holding the barcodes for the neutralization standard set.
 So in general, this key will look like:
-```
+```yaml
 neut_standard_sets:
   loes2023: data/neut_standard_sets/loes2023_neut_standards.csv
   <potentially more neut standard sets specified as name: CSV pairs>
@@ -213,7 +283,7 @@ neut_standard_sets:
 The recommended way to organize the neutralization-standard sets (as indicated above) is to put them in a `./data/neut_standard_sets/` subdirectory.
 
 The CSV files need just a single column specifying the neutralization standard barcode (which cannot contain whitespace), such as:
-```
+```csv
 barcode
 CTTTAAATTATAGTCT
 CATACAGAGTTTGTTG
@@ -227,7 +297,7 @@ This is a global dictionary that is applied to all plates, but can be augmented 
 This mapping should just specify key-word arguments that can be passed to [dms_variants.illuminabarcodeparser.IlluminaBarcodeParser](https://jbloomlab.github.io/dms_variants/dms_variants.illuminabarcodeparser.html#dms_variants.illuminabarcodeparser.IlluminaBarcodeParser); note that the barcode-length (`bclen`) parameter should not be specified as it is inferred from the length of the barcodes.
 
 So in general, this key will look like this:
-```
+```yaml
 illumina_barcode_parser_params:
   upstream: CTCCCTACAATGTCGGATTTGTATTTAATAG
   downstream: ''
@@ -246,7 +316,7 @@ Note that `sera_override_defaults` is keyed by group and so must then also be em
 
 The basic structure is that `plates` maps plate names (which cannot contain whitespace) to configurations for the plates.
 Specifically, it should look like this:
-```
+```yaml
 plates:
 
   plate1:
@@ -285,7 +355,7 @@ The `neut_standard_set` key gives the name of a key in `neut_standard_sets` that
 #### dilution_factor_or_concentration and concentration_units (optional)
 By default each plate titrates a serum *dilution_factor*, and titers are reported as reciprocal serum dilutions.
 Alternatively, a plate can titrate a *concentration* directly (for instance, the concentration of a monoclonal antibody) by setting:
-```
+```yaml
     dilution_factor_or_concentration: concentration
     concentration_units: ug/ml
 ```
@@ -311,7 +381,7 @@ The CSV file must have the following columns:
  - other columns (e.g., *notes*, etc) are allowed but are ignored by the pipeline
 
 Here are a few lines of an example CSV file:
-```
+```csv
 well,serum,dilution_factor,replicate,fastq
 A1,none,,1,/fh/fast/bloom_j/SR/ngs/illumina/aloes/230801_VH00319_391_AACWKHTM5/Unaligned/Project_aloes/Plate1_Noserum1_S1_R1_001.fastq.gz
 A2,Y106d182,20.0,1,/fh/fast/bloom_j/SR/ngs/illumina/aloes/230801_VH00319_391_AACWKHTM5/Unaligned/Project_aloes/Y106_d182_conc1_S9_R1_001.fastq.gz
@@ -335,7 +405,7 @@ The manual drops can have the following keys:
  - `serum_replicates`: list of serum-replicates to drop
 
 So for instance, you could have this specification if you wanted to drop barcode `AGTCCTATCCTCAAAT` for all wells of serum-replicate `M099d0`
-```
+```yaml
 manual_drops:
   barcode_serum_replicates:
     - [AGTCCTATCCTCAAAT, M099d0]
@@ -347,7 +417,7 @@ These thresholds are used for the QC in the `process_count` rule (see section be
 
 Since it is a bit complex, you typically will want to use the [YAML anchor / merge](https://ktomk.github.io/writing/yaml-anchor-alias-and-merge-key.html) syntax to define a default that you then merge for specific plates.
 The default can be defined like this:
-```
+```yaml
 default_process_plate_qc_thresholds: &default_process_plate_qc_thresholds
   avg_barcode_counts_per_well: 500
   min_neut_standard_frac_per_well: 0.005
@@ -366,7 +436,7 @@ default_process_plate_qc_thresholds: &default_process_plate_qc_thresholds
 ```
 and then for specific plates you can merge this default it in and overwrite any specific keys if needed.
 For instance, below would merge the above defaults but then overwrite the `min_viral_barcode_frac` to a different value:
-```
+```yaml
 plates:
 
   plate1:
@@ -403,7 +473,7 @@ This key defines some parameters specifying how the neutralization curves are fi
 
 You typically want to use the [YAML anchor/merge](https://ktomk.github.io/writing/yaml-anchor-alias-and-merge-key.html) syntax to define a default that you then merge for specific plates.
 The default can be defined like this:
-```
+```yaml
 default_process_plate_curvefit_params: &default_process_plate_curvefit_params
   frac_infectivity_ceiling: 1
   fixtop: [0.75, 1.0]
@@ -429,7 +499,7 @@ This key defines some parameters on quality-control performed after the curve-fi
 
 You typically want to use the [YAML anchor/merge](https://ktomk.github.io/writing/yaml-anchor-alias-and-merge-key.html) syntax to define a default that you then merge for specific plates.
 The default can be defined like this:
-```
+```yaml
 default_process_plate_curvefit_qc:  &default_process_plate_curvefit_qc
   max_frac_infectivity_at_least: 0
   goodness_of_fit:
@@ -460,11 +530,11 @@ The main anticipated use case is if you add plate-specific indices in the round 
 ### default_serum_titer_as
 Specifies how we compute the final titers in `serum_titers`.
 Can be either `midpoint` or `nt50` depending on whether you want to report the value where the fraction infectivity gets to 50%, or the midpoint of the curve, so should be either
-```
+```yaml
 default_serum_titer_as: midpoint
 ```
 or
-```
+```yaml
 default_serum_titer_as: nt50
 ```
 The difference only becomes relevant if some your curves have plateaus substantially different than zero and one.
@@ -478,7 +548,7 @@ Default QC we apply to each serum-virus pair when reporting out the final titers
 Any serum-virus pair that fails this QC does not have a titer reported unless it is specified in `sera_override_defaults`.
 
 Should look like this:
-```
+```yaml
 default_serum_qc_thresholds: &default_serum_qc_thresholds
   min_replicates: 2
   max_fold_change_from_median: 3
@@ -493,7 +563,7 @@ where:
 ### sera_override_defaults
 Override `default_serum_titer_as` or `default_serum_qc_thresholds` for specific sera in each group (recall groups are assigned per-plate).
 For instance, this could look like:
-```
+```yaml
 sera_override_defaults:
   serum:
     M099d30:
@@ -520,7 +590,7 @@ Neither the plate names nor the wells in their `samples_csv` can contain whitesp
 
 The key should look like this:
 
-```
+```yaml
 miscellaneous_plates:
 
   <plate_name_1>:
@@ -555,6 +625,9 @@ The results of running the pipeline are put in the `./results/` subdirectory of 
 We recommend using the `.gitignore` file in [./test_example/.gitignore](test_example/.gitignore) in your main repo to only track key results in your GitHub repo.
 The key results if the pipeline runs to completion are in `./results/aggregated_titers/titers_{group}.csv` for each group of sera.
 The set of full created outputs are as follows (note only some will be tracked depending on your `.gitignore`):
+
+  - Output related to validating the viral libraries, if `viral_library_validations` is configured:
+    - `./results/validate_viral_library/{viral_library}_validation.txt`: a report of each viral library and of every check applied to it. You should track this in the repo, as it is the only record of what a library was actually checked against.
 
   - Outputs related to barcode counting:
     - `./results/barcode_counts/`: files giving the barcode counts for each sample. You should track this in the repo.
@@ -681,7 +754,7 @@ pytest
 The code is organized as follows.
 [seqneut-pipeline.smk](seqneut-pipeline.smk) defines the rules, and [funcs.smk](funcs.smk) holds the helpers that process and validate the configuration and sample tables while those rules are being defined.
 The rules themselves are thin: the analysis is in the scripts in [./scripts](scripts), one per rule, which also write the HTML reports that make up the documentation.
-Those reports are built by [scripts/seqneut_report.py](scripts/seqneut_report.py), and [scripts/seqneut_funcs.py](scripts/seqneut_funcs.py) holds the analysis functions used by more than one script; both are covered by the tests in [./tests](tests).
+Those reports are built by [scripts/seqneut_report.py](scripts/seqneut_report.py), [scripts/seqneut_funcs.py](scripts/seqneut_funcs.py) holds the analysis functions used by more than one script, and [scripts/viral_library_validation.py](scripts/viral_library_validation.py) holds the viral library checks; all three are covered by the tests in [./tests](tests).
 Note that `snakemake` re-runs a `script:` rule when the script itself changes but does not follow the script's imports, so a rule lists the modules its script imports among its `input`.
 
 Please raise [GitHub issues](https://github.com/jbloomlab/seqneut-pipeline/issues) or [make a pull request](https://github.com/jbloomlab/seqneut-pipeline/pulls) to improve the pipeline.

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ channels:
 
 dependencies:
   - altair=6.2
+  - biopython=1.88
   - black
   - marimo=0.23  # not used by pipeline, but kept for now in case custom scripts use it
   - markdown=3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "seqneut-pipeline"
-version = "9.1.0"
+version = "9.2.0"
 description = "Modular analysis pipeline for high-throughput sequencing-based neutralization assays"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/validate_viral_library.py
+++ b/scripts/validate_viral_library.py
@@ -1,0 +1,23 @@
+"""Validate a viral library CSV against the checks configured for it in `config.yml`."""
+
+import sys
+
+import viral_library_validation
+
+# `noqa: SIM115` as this log file must stay open for the life of the script
+sys.stderr = sys.stdout = open(snakemake.log[0], "w")  # noqa: SIM115
+
+try:
+    report = viral_library_validation.report(
+        snakemake.input.csv, snakemake.params.validations
+    )
+except viral_library_validation.LibraryError as e:
+    # the report of a failed run is written too, so that it says what the library did get
+    # through rather than only naming the first thing wrong with it
+    print(e.report)
+    raise
+
+print(report)
+
+with open(snakemake.output.validation, "w") as f:
+    f.write(f"{report}\n")

--- a/scripts/viral_library_validation.py
+++ b/scripts/viral_library_validation.py
@@ -1,0 +1,698 @@
+"""Validation of a viral library CSV against the checks configured for it.
+
+The checks are declared per column in `viral_library_validations`, so that only `strain`
+and `barcode` are named here: they are the sole columns `seqneut-pipeline` itself reads,
+and everything else a library carries is described entirely by the configuration.
+
+Nothing here reads or writes a file beyond the library CSV, and nothing prints, so that
+every check can be exercised directly by the tests.
+
+"""
+
+import collections
+import re
+
+import Bio.Data.CodonTable
+import Bio.Seq
+import pandas as pd
+
+# the only columns `seqneut-pipeline` itself reads from a viral library
+REQUIRED_COLS = {"strain", "barcode"}
+
+# the keys a `columns` entry may have, the subset a `groups` entry may have, and the
+# values `unique` may take
+SPEC_KEYS = {
+    "nulls",
+    "unique",
+    "unique_within",
+    "values",
+    "non_null_when",
+    "matches",
+    "length",
+    "translates_to",
+    "numeric",
+    "by",
+    "groups",
+}
+GROUP_KEYS = {"matches", "length"}
+UNIQUE_VALUES = {"barcode", "strain"}
+
+# how many failing values a failed check names before it just gives the count
+MAX_OFFENDERS_SHOWN = 10
+
+# the sections of the report, in the order it presents them
+SECTIONS = ["columns", "numbers", "patterns", "uniqueness", "sequences"]
+
+# a check of a library, in the section of the report it belongs to. `offenders` empty
+# means the check passed; `id` names the check stably, as `description` interpolates
+# configured values and so is not something to match on.
+Check = collections.namedtuple(
+    "Check", ["id", "section", "description", "examined", "offenders"]
+)
+
+
+class SpecError(ValueError):
+    """The `viral_library_validations` entry for a library is itself malformed."""
+
+
+class LibraryError(ValueError):
+    """A viral library failed the checks configured for it.
+
+    `failures` holds the failed `Check`s and `report` the whole report, so that a failing
+    run still says everything the library got through.
+
+    """
+
+    def __init__(self, message, failures, report):
+        super().__init__(message)
+        self.failures = failures
+        self.report = report
+
+
+def _require(condition, message):
+    """Raise `SpecError` describing a malformed spec unless `condition` holds."""
+    if not condition:
+        raise SpecError(f"`viral_library_validations` is invalid: {message}")
+
+
+def _validate_patterns(spec, where):
+    """Validate the `matches` and `length` of a column or group spec, described by `where`."""
+    if "matches" in spec:
+        _require(
+            isinstance(spec["matches"], list) and spec["matches"],
+            f"`{where}: matches` must be a non-empty list of regexes",
+        )
+        for pattern in spec["matches"]:
+            _require(
+                isinstance(pattern, str),
+                f"`{where}: matches` holds {pattern!r}, which is not a regex",
+            )
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                _require(
+                    False, f"`{where}: matches` holds invalid regex {pattern!r}: {e}"
+                )
+    if "length" in spec:
+        length = spec["length"]
+        _require(
+            isinstance(length, dict) and set(length) == {"min", "max"},
+            f"`{where}: length` must have exactly `min` and `max`, but has "
+            f"{sorted(length) if isinstance(length, dict) else length!r}",
+        )
+        _require(
+            all(isinstance(length[k], int) for k in ("min", "max"))
+            and length["min"] <= length["max"],
+            f"`{where}: length` must be integers with `min` no greater than `max`, "
+            f"but is {length}",
+        )
+
+
+def _require_non_null_grouping(col_specs, grouping_col, where):
+    """Require `grouping_col` to be non-null, as it partitions the rows of a check.
+
+    A row whose grouping column is empty belongs to no group, and so would be quietly
+    dropped from the check the grouping keys rather than failing it.
+
+    """
+    _require(
+        not col_specs[grouping_col]["nulls"],
+        f"`{where}` groups on {grouping_col!r}, which must be declared `nulls: false`: a "
+        "row that does not set it belongs to no group and so would go unchecked",
+    )
+
+
+def validate_spec(spec):
+    """Raise `SpecError` describing `spec` unless it is valid checks for one library.
+
+    Called before the library is read, so that a configuration error is never reported as
+    though it were a problem with the data.
+
+    """
+    _require(
+        isinstance(spec, dict) and set(spec) == {"columns"},
+        "each library's entry must have exactly the key `columns`, but has "
+        f"{sorted(spec) if isinstance(spec, dict) else spec!r}",
+    )
+    col_specs = spec["columns"]
+    _require(
+        isinstance(col_specs, dict) and col_specs,
+        "`columns` must be a non-empty mapping of column name to its checks",
+    )
+    _require(
+        REQUIRED_COLS <= set(col_specs),
+        f"`columns` must list {sorted(REQUIRED_COLS)}, the columns `seqneut-pipeline` "
+        f"itself reads, but is missing {sorted(REQUIRED_COLS - set(col_specs))}",
+    )
+
+    for col, col_spec in col_specs.items():
+        where = f"columns: {col}"
+        _require(
+            isinstance(col_spec, dict),
+            f"`{where}` must be a mapping of check name to its value",
+        )
+        _require(
+            not set(col_spec) - SPEC_KEYS,
+            f"`{where}` has unknown keys {sorted(set(col_spec) - SPEC_KEYS)}, "
+            f"expected some of {sorted(SPEC_KEYS)}",
+        )
+        _require(
+            isinstance(col_spec.get("nulls"), bool),
+            f"`{where}` must declare `nulls` as true or false",
+        )
+
+        if "unique" in col_spec:
+            _require(
+                col_spec["unique"] in UNIQUE_VALUES,
+                f"`{where}` has `unique: {col_spec['unique']}`, expected one of "
+                f"{sorted(UNIQUE_VALUES)}",
+            )
+            # a strain names itself, so the check would hold no matter what the data said
+            _require(
+                not (col == "strain" and col_spec["unique"] == "strain"),
+                "`columns: strain` cannot have `unique: strain`, which asks whether a "
+                "strain names one strain and so is true of any library",
+            )
+        if "unique_within" in col_spec:
+            _require(
+                col_spec.get("unique") == "strain",
+                f"`{where}` has `unique_within` without `unique: strain`, which is the "
+                "only check it scopes",
+            )
+            _require(
+                col_spec["unique_within"] in col_specs
+                and col_spec["unique_within"] != col,
+                f"`{where}` has `unique_within: {col_spec['unique_within']}`, which is "
+                "not another column listed in `columns`",
+            )
+            _require_non_null_grouping(col_specs, col_spec["unique_within"], where)
+
+        if "values" in col_spec:
+            _require(
+                isinstance(col_spec["values"], list) and col_spec["values"],
+                f"`{where}: values` must be a non-empty list",
+            )
+            # the CSV is read as text, so an unquoted YAML boolean or number would be
+            # compared as a Python object and match nothing in the library
+            _require(
+                all(isinstance(v, str) for v in col_spec["values"]),
+                f"`{where}: values` must all be strings, but holds "
+                f"{[v for v in col_spec['values'] if not isinstance(v, str)]}; quote "
+                "them, as the library is read as text",
+            )
+
+        if "non_null_when" in col_spec:
+            when = col_spec["non_null_when"]
+            _require(
+                isinstance(when, dict) and len(when) == 1,
+                f"`{where}: non_null_when` must name exactly one column, but names "
+                f"{sorted(when) if isinstance(when, dict) else when!r}",
+            )
+            ((when_col, when_val),) = when.items()
+            _require(
+                when_col in col_specs,
+                f"`{where}: non_null_when` names {when_col!r}, which `columns` does not "
+                "list",
+            )
+            when_values = col_specs[when_col].get("values")
+            _require(
+                when_values is None or when_val in when_values,
+                f"`{where}: non_null_when` expects {when_col} == {when_val!r}, which is "
+                f"not among the {when_values} that column may hold",
+            )
+
+        if "translates_to" in col_spec:
+            _require(
+                col_spec["translates_to"] in col_specs
+                and col_spec["translates_to"] != col,
+                f"`{where}: translates_to` names {col_spec['translates_to']!r}, which "
+                "is not another column listed in `columns`",
+            )
+        if "numeric" in col_spec:
+            _require(
+                isinstance(col_spec["numeric"], bool),
+                f"`{where}: numeric` must be true or false",
+            )
+        _validate_patterns(col_spec, where)
+
+        if "by" in col_spec or "groups" in col_spec:
+            _require(
+                "by" in col_spec and "groups" in col_spec,
+                f"`{where}` must have `by` and `groups` together, as `by` names the "
+                "column whose values key `groups`",
+            )
+            by_col = col_spec["by"]
+            _require(
+                by_col in col_specs and by_col != col,
+                f"`{where}: by` names {by_col!r}, which is not another column listed in "
+                "`columns`",
+            )
+            by_values = col_specs[by_col].get("values")
+            _require(
+                by_values is not None,
+                f"`{where}: by` names {by_col!r}, which must declare the `values` that "
+                "key `groups`",
+            )
+            _require_non_null_grouping(col_specs, by_col, where)
+            _require(
+                set(col_spec["groups"]) == set(by_values),
+                f"`{where}: groups` is keyed by {sorted(col_spec['groups'])}, but "
+                f"`{by_col}` holds {sorted(by_values)}; every value needs an entry and "
+                "an entry for anything else would never be applied",
+            )
+            for group, group_spec in col_spec["groups"].items():
+                group_where = f"{where}: groups: {group}"
+                _require(
+                    isinstance(group_spec, dict) and group_spec,
+                    f"`{group_where}` must be a non-empty mapping",
+                )
+                _require(
+                    not set(group_spec) - GROUP_KEYS,
+                    f"`{group_where}` has unknown keys "
+                    f"{sorted(set(group_spec) - GROUP_KEYS)}, expected some of "
+                    f"{sorted(GROUP_KEYS)}",
+                )
+                _validate_patterns(group_spec, group_where)
+
+
+def read_library(csv):
+    """Read a viral library CSV, every column as text so no identifier becomes a number."""
+    return pd.read_csv(csv, dtype=str)
+
+
+def describe_column(col, spec):
+    """Human-readable summary of the checks `spec` configures on column `col`."""
+    col_spec = spec["columns"].get(col)
+    if col_spec is None:
+        return "NOT VALIDATED"
+    parts = ["nulls allowed" if col_spec["nulls"] else "non-null"]
+    if col_spec.get("unique") == "barcode":
+        parts.append("distinct per row")
+    elif col_spec.get("unique") == "strain":
+        within = col_spec.get("unique_within")
+        parts.append(
+            f"names one strain within its {within}" if within else "names one strain"
+        )
+    if "values" in col_spec:
+        parts.append(f"values {col_spec['values']}")
+    if "non_null_when" in col_spec:
+        ((when_col, when_val),) = col_spec["non_null_when"].items()
+        parts.append(f"set when {when_col} is {when_val}")
+    for pattern in col_spec.get("matches", []):
+        parts.append(f"matches {pattern}")
+    if "length" in col_spec:
+        parts.append(f"length {col_spec['length']['min']}-{col_spec['length']['max']}")
+    if "by" in col_spec:
+        parts.append(f"further checks per {col_spec['by']}")
+    if "translates_to" in col_spec:
+        parts.append(f"translates to {col_spec['translates_to']}")
+    if col_spec.get("numeric"):
+        parts.append("a number")
+    return "; ".join(parts)
+
+
+def _table_lines(header, rows, last_free=True):
+    """Lines of a table, the first column left-aligned and the rest right-aligned.
+
+    The last column is left as written where `last_free`, as it holds free text too wide
+    to pad every other row out to.
+
+    """
+    n = len(header) - 1 if last_free else len(header)
+    widths = [max(len(row[i]) for row in [header, *rows]) for i in range(n)]
+    return [
+        "  "
+        + row[0].ljust(widths[0])
+        + "".join(f"  {v.rjust(w)}" for v, w in zip(row[1:n], widths[1:]))
+        + (f"  {row[-1]}" if last_free else "")
+        for row in [header, *rows]
+    ]
+
+
+def summary_lines(df, spec, csv):
+    """Lines describing the library, its categorical columns, and every column in it."""
+    col_specs = spec["columns"]
+    lines = [
+        f"=== summary of {csv} ===",
+        f"{len(df)} barcodes for {df['strain'].nunique()} strains",
+    ]
+
+    # a breakdown per value of every column declared categorical, so that the summary
+    # names no particular column of its own
+    strains = df.drop_duplicates("strain")
+    for col, col_spec in col_specs.items():
+        if "values" not in col_spec:
+            continue
+        lines.append("")
+        lines.extend(
+            _table_lines(
+                (col, "strains", "barcodes"),
+                [
+                    (
+                        f"  {value}",
+                        str(int((strains[col] == value).sum())),
+                        str(int((df[col] == value).sum())),
+                    )
+                    for value in col_spec["values"]
+                ],
+                last_free=False,
+            )
+        )
+
+    # one row per column of the CSV, in the order the CSV has them, so that a column the
+    # configuration does not mention still shows up rather than passing unnoticed
+    lines.append("")
+    lines.extend(
+        _table_lines(
+            ("column", "null", "non-null", "distinct", "max per strain", "checks"),
+            [
+                (
+                    col,
+                    str(int(df[col].isnull().sum())),
+                    str(int(df[col].notnull().sum())),
+                    str(int(df[col].nunique())),  # counts distinct non-null values
+                    str(int(df.groupby("strain")[col].nunique(dropna=False).max())),
+                    describe_column(col, spec),
+                )
+                for col in df.columns
+            ],
+        )
+    )
+
+    unlisted = [col for col in df.columns if col not in col_specs]
+    lines.append(
+        "\ncolumns not listed in `viral_library_validations: columns`: "
+        + (str(unlisted) if unlisted else "none")
+    )
+    return lines
+
+
+def _offenders(df, failed, col):
+    """The strains and values of the rows of `df` where the boolean `failed` holds."""
+    rows = df.loc[failed]
+    return [f"{strain}: {value!r}" for strain, value in zip(rows["strain"], rows[col])]
+
+
+def schema_checks(df, spec):
+    """Checks that the library has the columns the spec lists."""
+    col_specs = spec["columns"]
+    yield Check(
+        id="schema",
+        section="schema",
+        description="all columns listed in `columns` are present",
+        examined=f"{len(col_specs)} columns",
+        offenders=[col for col in col_specs if col not in df.columns],
+    )
+
+
+def column_checks(df, spec):
+    """Checks of `nulls`, `values`, `non_null_when`, and `numeric`."""
+    col_specs = spec["columns"]
+    non_null_cols = [col for col, s in col_specs.items() if not s["nulls"]]
+    yield Check(
+        id="nulls",
+        section="columns",
+        description="columns declared non-null have no null values",
+        examined=f"{len(non_null_cols)} columns",
+        offenders=[
+            f"{col}: {int(df[col].isnull().sum())} null"
+            for col in non_null_cols
+            if df[col].isnull().any()
+        ],
+    )
+    for col, col_spec in col_specs.items():
+        set_rows = df[df[col].notnull()]
+        if "values" in col_spec:
+            yield Check(
+                id=f"values:{col}",
+                section="columns",
+                description=f"`{col}` holds only {col_spec['values']}",
+                examined=f"{len(set_rows)} non-null rows",
+                offenders=sorted(
+                    set(set_rows.loc[~set_rows[col].isin(col_spec["values"]), col])
+                ),
+            )
+        if "non_null_when" in col_spec:
+            ((when_col, when_val),) = col_spec["non_null_when"].items()
+            yield Check(
+                id=f"non_null_when:{col}",
+                section="columns",
+                description=(
+                    f"`{col}` is set for exactly the rows with {when_col} "
+                    f"== {when_val}"
+                ),
+                examined=f"{len(df)} rows",
+                offenders=sorted(
+                    set(
+                        df.loc[
+                            df[col].notnull() != (df[when_col] == when_val), "strain"
+                        ]
+                    )
+                ),
+            )
+        if col_spec.get("numeric"):
+            yield Check(
+                id=f"numeric:{col}",
+                section="numbers",
+                description=f"`{col}` is a number",
+                examined=f"{len(set_rows)} non-null rows",
+                offenders=_offenders(
+                    set_rows, pd.to_numeric(set_rows[col], errors="coerce").isna(), col
+                ),
+            )
+
+
+def _pattern_checks_over(df, col, patterns, length, id_suffix, described):
+    """Checks of `patterns` and `length` over the rows of `df` that set `col`."""
+    set_rows = df[df[col].notnull()]
+    examined = f"{len(set_rows)} non-null rows"
+    for pattern in patterns:
+        yield Check(
+            id=f"matches:{col}:{id_suffix}{pattern}",
+            section="patterns",
+            description=f"`{col}`{described} matches {pattern}",
+            examined=examined,
+            offenders=_offenders(
+                set_rows,
+                ~set_rows[col].map(re.compile(pattern).search).astype(bool),
+                col,
+            ),
+        )
+    if length is not None:
+        lengths = set_rows[col].str.len()
+        yield Check(
+            id=f"length:{col}:{id_suffix}".rstrip(":"),
+            section="patterns",
+            description=(
+                f"`{col}`{described} is {length['min']} to {length['max']} characters"
+                if length["min"] != length["max"]
+                else f"`{col}`{described} is {length['min']} characters"
+            ),
+            examined=examined,
+            offenders=_offenders(
+                set_rows, (lengths < length["min"]) | (lengths > length["max"]), col
+            ),
+        )
+
+
+def pattern_checks(df, spec):
+    """Checks of `matches` and `length`, including those keyed by `by` and `groups`."""
+    for col, col_spec in spec["columns"].items():
+        yield from _pattern_checks_over(
+            df, col, col_spec.get("matches", []), col_spec.get("length"), "", ""
+        )
+        for group, group_spec in col_spec.get("groups", {}).items():
+            yield from _pattern_checks_over(
+                df[df[col_spec["by"]] == group],
+                col,
+                group_spec.get("matches", []),
+                group_spec.get("length"),
+                f"{group}:",
+                f" where {col_spec['by']} is {group}",
+            )
+
+
+def uniqueness_checks(df, spec):
+    """Checks of `unique`, `unique_within`, and that a strain's barcodes agree."""
+    col_specs = spec["columns"]
+    for col, col_spec in col_specs.items():
+        # nulls are excluded, so a column that is optional per barcode can still be
+        # required to identify the barcodes that do set it
+        set_rows = df[df[col].notnull()]
+        if col_spec.get("unique") == "barcode":
+            yield Check(
+                id=f"unique_barcode:{col}",
+                section="uniqueness",
+                description=f"`{col}` is distinct in every row that sets it",
+                examined=f"{len(set_rows)} non-null rows",
+                offenders=sorted(set(set_rows.loc[set_rows[col].duplicated(), col])),
+            )
+        elif col_spec.get("unique") == "strain":
+            within = col_spec.get("unique_within")
+            keys = ([within] if within else []) + [col]
+            per_value = set_rows.drop_duplicates([*keys, "strain"]).groupby(keys)[
+                "strain"
+            ]
+            yield Check(
+                id=f"unique_strain:{col}",
+                section="uniqueness",
+                description=(
+                    f"each `{col}` value names one strain within its {within}"
+                    if within
+                    else f"each `{col}` value names one strain"
+                ),
+                examined=f"{len(per_value)} distinct values",
+                offenders=per_value.apply(list)[per_value.nunique() > 1].tolist(),
+            )
+
+    # every column but a `unique: barcode` one describes the strain, so it must hold the
+    # same value on each of that strain's barcodes
+    # `strain` groups this check, so it stays even where it is declared per barcode --
+    # a library of one barcode per strain may legitimately say so
+    per_barcode_cols = [
+        col
+        for col, s in col_specs.items()
+        if s.get("unique") == "barcode" and col != "strain"
+    ]
+    per_strain = df[list(col_specs)].drop(columns=per_barcode_cols).drop_duplicates()
+    yield Check(
+        id="constant_per_strain",
+        section="uniqueness",
+        description=(
+            f"each strain has one set of values for all listed columns but "
+            f"{per_barcode_cols}"
+        ),
+        examined=f"{df['strain'].nunique()} strains",
+        offenders=sorted(
+            set(per_strain.loc[per_strain["strain"].duplicated(keep=False), "strain"])
+        ),
+    )
+
+
+def _translation(nt):
+    """The protein `nt` translates to, or `None` where it is not a coding sequence.
+
+    What the sequence column may actually hold is the `matches` regex's business, so this
+    tries to translate anything of a whole number of codons and reports what will not
+    translate as a failure of `translates_to` rather than as a crash. Duplicating the
+    format check here would instead make one malformed sequence fail both.
+
+    """
+    if len(nt) % 3:  # a partial codon, which `Bio` only warns about
+        return None
+    try:
+        return str(Bio.Seq.Seq(nt).translate())
+    except Bio.Data.CodonTable.TranslationError:
+        return None
+
+
+def sequence_checks(df, spec):
+    """Checks of `translates_to`."""
+    for col, col_spec in spec["columns"].items():
+        if "translates_to" not in col_spec:
+            continue
+        protein_col = col_spec["translates_to"]
+        rows = df[df[col].notnull() & df[protein_col].notnull()]
+        yield Check(
+            id=f"translates_to:{col}",
+            section="sequences",
+            description=f"`{col}` translates to `{protein_col}`",
+            examined=f"{len(rows)} rows setting both",
+            offenders=sorted(
+                {
+                    strain
+                    for strain, nt, protein in zip(
+                        rows["strain"], rows[col], rows[protein_col]
+                    )
+                    if _translation(nt) != protein
+                }
+            ),
+        )
+
+
+def library_checks(df, spec):
+    """Every check `spec` configures on library `df`, as `Check`s in report order."""
+    yield from column_checks(df, spec)
+    yield from pattern_checks(df, spec)
+    yield from uniqueness_checks(df, spec)
+    yield from sequence_checks(df, spec)
+
+
+def numeric_lines(df, spec):
+    """Lines reporting the range of each column declared `numeric`."""
+    lines = []
+    for col, col_spec in spec["columns"].items():
+        if not col_spec.get("numeric"):
+            continue
+        # one value per strain, so a strain carrying several barcodes is not weighted by
+        # them; two decimals is the precision a decimal-year date is recorded to
+        values = pd.to_numeric(
+            df.drop_duplicates("strain")[col], errors="coerce"
+        ).dropna()
+        lines.append(
+            f"      `{col}` over {len(values)} strains:  min {values.min():.2f}"
+            f"  median {values.median():.2f}  max {values.max():.2f}"
+            if len(values)
+            else f"      `{col}`: no numeric values over {len(values)} strains"
+        )
+    return lines
+
+
+def _check_lines(checks, width):
+    """Lines reporting `checks`, each naming what it examined and any failures."""
+    lines = []
+    for c in checks:
+        status = "FAIL" if c.offenders else " OK "
+        lines.append(f"  {status}  {c.description.ljust(width)}  ({c.examined})")
+        if c.offenders:
+            shown = c.offenders[:MAX_OFFENDERS_SHOWN]
+            more = len(c.offenders) - len(shown)
+            lines.append(
+                f"        {len(c.offenders)} failures: {shown}"
+                + (f" and {more} more" if more else "")
+            )
+    return lines
+
+
+def report(csv, spec):
+    """Validate the viral library `csv` against `spec`.
+
+    Returns the report as text. Raises `SpecError` if `spec` is malformed, and
+    `LibraryError` carrying the whole report if any check fails.
+
+    """
+    validate_spec(spec)
+    df = read_library(csv)
+
+    schema = list(schema_checks(df, spec))
+    # nothing else can be checked against columns that are not there, so a failed schema
+    # ends the report rather than raising a `KeyError` from every check after it
+    if any(c.offenders for c in schema):
+        text = "\n".join(
+            ["=== schema ===", *_check_lines(schema, len(schema[0].description))]
+        )
+        raise LibraryError(f"{csv} is missing listed columns", schema, text)
+
+    checks = list(library_checks(df, spec))
+    width = max(len(c.description) for c in [*schema, *checks])
+    lines = ["=== schema ===", *_check_lines(schema, width), ""]
+    lines.extend(summary_lines(df, spec, csv))
+    # a fixed order, so the report does not depend on the order the checks are yielded in
+    for section in SECTIONS:
+        in_section = [c for c in checks if c.section == section]
+        # the range of a numeric column is reported alongside the check that it is one
+        extra = numeric_lines(df, spec) if section == "numbers" else []
+        if in_section or extra:
+            lines.extend(["", f"=== {section} ===", *_check_lines(in_section, width)])
+            lines.extend(extra)
+    text = "\n".join(lines)
+
+    failures = [c for c in checks if c.offenders]
+    if failures:
+        raise LibraryError(
+            f"{len(failures)} check{'s' if len(failures) > 1 else ''} failed for "
+            f"{csv}: {[c.description for c in failures]}",
+            failures,
+            text,
+        )
+    return text

--- a/seqneut-pipeline.smk
+++ b/seqneut-pipeline.smk
@@ -21,6 +21,16 @@ viral_libraries = {
     lib: pd.read_csv(f) for (lib, f) in config["viral_libraries"].items()
 }
 
+# optional key; absent or null means no library is validated. Keyed by library so that
+# libraries with different schemas each get their own checks.
+viral_library_validations = config.get("viral_library_validations") or {}
+if viral_library_validations and set(viral_library_validations) != set(viral_libraries):
+    raise ValueError(
+        "`viral_library_validations` must have an entry for every library in "
+        f"`viral_libraries`, but is keyed by {sorted(viral_library_validations)} rather "
+        f"than {sorted(viral_libraries)}"
+    )
+
 if ("viral_strain_plot_order" not in config) or (
     config["viral_strain_plot_order"] is None
 ):
@@ -102,6 +112,7 @@ corr_plates = {
 
 wildcard_constraints:
     group="|".join(groups),
+    viral_library="|".join(re.escape(lib) for lib in viral_libraries),
 
 
 # like `plates`, may be absent or null, both of which mean no sera override the defaults
@@ -134,6 +145,27 @@ except NameError:  # if not defined
 
 
 # --- Snakemake rules -------------------------------------------------------------------
+
+if viral_library_validations:
+
+    rule validate_viral_library:
+        """Validate a viral library CSV against the checks configured for it."""
+        input:
+            csv=lambda wc: config["viral_libraries"][wc.viral_library],
+            validation_module=os.path.join(
+                pipeline_subdir, "scripts/viral_library_validation.py"
+            ),
+        output:
+            validation="results/validate_viral_library/{viral_library}_validation.txt",
+        log:
+            "results/logs/validate_viral_library_{viral_library}.txt",
+        conda:
+            "environment.yml"
+        params:
+            validations=lambda wc: viral_library_validations[wc.viral_library],
+        script:
+            "scripts/validate_viral_library.py"
+
 
 if plates:
 
@@ -489,6 +521,16 @@ rule build_docs:
 
 
 seqneut_pipeline_outputs = [
+    # `rules.validate_viral_library` does not exist when no validations are configured,
+    # so the guard is what keeps this from raising rather than just documenting intent
+    *(
+        expand(
+            rules.validate_viral_library.output.validation,
+            viral_library=viral_library_validations,
+        )
+        if viral_library_validations
+        else []
+    ),
     *(
         [
             rules.aggregate_titers.output.titers,

--- a/test_example/.gitignore
+++ b/test_example/.gitignore
@@ -9,6 +9,8 @@ _*
 results/**
 !results/**/
 
+!results/validate_viral_library/*_validation.txt
+
 !results/barcode_counts/*.csv
 !results/barcode_fates/*.csv
 

--- a/test_example/config.yml
+++ b/test_example/config.yml
@@ -22,6 +22,18 @@ viral_libraries:
   pdmH1N1_lib2023_loes: data/viral_libraries/pdmH1N1_lib2023_loes.csv
   H3N2_lib2023_Kikawa: data/viral_libraries/2023_H3N2_Kikawa.csv
 
+# Optional checks on each library in `viral_libraries`, one entry per library. These two
+# have only the `barcode` and `strain` that the pipeline itself reads, so there is nothing
+# else to check; a real project may describe other columns as well.
+viral_library_validations:
+  pdmH1N1_lib2023_loes: &library_validations
+    columns:
+      # uppercase is required, not merely conventional: the uniqueness check compares
+      # exact strings, so a lowercase barcode would not collide with its uppercase twin
+      barcode: {nulls: false, unique: barcode, matches: ['^[ACGT]{16}$']}
+      strain: {nulls: false, matches: ['^\S+$']}
+  H3N2_lib2023_Kikawa: *library_validations
+
 viral_strain_plot_order: data/viral_strain_plot_order.csv
 
 curve_display_method: svg  # {svg, pdf, png8}; svg best resolution, png8 smallest

--- a/test_example/config_bad_viral_library.yml
+++ b/test_example/config_bad_viral_library.yml
@@ -1,0 +1,10 @@
+# === Overrides making a viral library fail its validation ==============================
+
+# Used by the tests to check that a library which does not meet its configured checks
+# stops the run rather than passing quietly. The barcodes really are 16 nucleotides, so
+# requiring 12 fails every row of this library.
+
+viral_library_validations:
+  pdmH1N1_lib2023_loes:
+    columns:
+      barcode: {nulls: false, unique: barcode, matches: ["^[ACGT]{12}$"]}

--- a/test_example/results/validate_viral_library/H3N2_lib2023_Kikawa_validation.txt
+++ b/test_example/results/validate_viral_library/H3N2_lib2023_Kikawa_validation.txt
@@ -1,0 +1,22 @@
+=== schema ===
+   OK   all columns listed in `columns` are present                               (2 columns)
+
+=== summary of data/viral_libraries/2023_H3N2_Kikawa.csv ===
+237 barcodes for 79 strains
+
+  column   null  non-null  distinct  max per strain  checks
+  barcode     0       237       237               3  non-null; distinct per row; matches ^[ACGT]{16}$
+  strain      0       237        79               1  non-null; matches ^\S+$
+
+columns not listed in `viral_library_validations: columns`: none
+
+=== columns ===
+   OK   columns declared non-null have no null values                             (2 columns)
+
+=== patterns ===
+   OK   `barcode` matches ^[ACGT]{16}$                                            (237 non-null rows)
+   OK   `strain` matches ^\S+$                                                    (237 non-null rows)
+
+=== uniqueness ===
+   OK   `barcode` is distinct in every row that sets it                           (237 non-null rows)
+   OK   each strain has one set of values for all listed columns but ['barcode']  (79 strains)

--- a/test_example/results/validate_viral_library/pdmH1N1_lib2023_loes_validation.txt
+++ b/test_example/results/validate_viral_library/pdmH1N1_lib2023_loes_validation.txt
@@ -1,0 +1,22 @@
+=== schema ===
+   OK   all columns listed in `columns` are present                               (2 columns)
+
+=== summary of data/viral_libraries/pdmH1N1_lib2023_loes.csv ===
+110 barcodes for 36 strains
+
+  column   null  non-null  distinct  max per strain  checks
+  barcode     0       110       110               4  non-null; distinct per row; matches ^[ACGT]{16}$
+  strain      0       110        36               1  non-null; matches ^\S+$
+
+columns not listed in `viral_library_validations: columns`: none
+
+=== columns ===
+   OK   columns declared non-null have no null values                             (2 columns)
+
+=== patterns ===
+   OK   `barcode` matches ^[ACGT]{16}$                                            (110 non-null rows)
+   OK   `strain` matches ^\S+$                                                    (110 non-null rows)
+
+=== uniqueness ===
+   OK   `barcode` is distinct in every row that sets it                           (110 non-null rows)
+   OK   each strain has one set of values for all listed columns but ['barcode']  (36 strains)

--- a/tests/test_viral_library_validation.py
+++ b/tests/test_viral_library_validation.py
@@ -1,0 +1,437 @@
+"""Tests for ``scripts/viral_library_validation.py``.
+
+Every check exists to stop a bad library, so each is exercised by an input that breaks it
+and by nothing else, and `TestEveryCheckFails` fails if a check is ever added without such
+an input.
+
+"""
+
+import pandas as pd
+import pytest
+from viral_library_validation import (
+    LibraryError,
+    SpecError,
+    describe_column,
+    library_checks,
+    numeric_lines,
+    report,
+    summary_lines,
+    validate_spec,
+)
+
+# a spec exercising every check, with short barcodes and sequences so that a test frame
+# can be read at a glance
+SPEC = {
+    "columns": {
+        "strain": {"nulls": False, "matches": [r"^\S+$"]},
+        "barcode": {"nulls": False, "unique": "barcode", "matches": ["^[ACGT]{4}$"]},
+        "plasmid_id": {"nulls": True, "unique": "barcode"},
+        "subtype": {"nulls": False, "values": ["H1N1", "H3N2"]},
+        "strain_type": {"nulls": False, "values": ["vaccine", "circulating"]},
+        "vaccine_type": {
+            "nulls": True,
+            "values": ["egg"],
+            "non_null_when": {"strain_type": "vaccine"},
+        },
+        "haplotype": {"nulls": False, "unique": "strain", "unique_within": "subtype"},
+        "collection_date": {"nulls": False, "numeric": True},
+        # no `unique: strain`, which translation would make redundant: an nt sequence
+        # naming two strains forces its protein to name them too
+        "nt_seq": {
+            "nulls": False,
+            "matches": ["^([ACGT]{3})+$"],
+            "translates_to": "prot_seq",
+        },
+        "prot_seq": {
+            "nulls": False,
+            "unique": "strain",
+            "matches": ["^[ACDEFGHIKLMNPQRSTVWY]+$"],
+            "length": {"min": 2, "max": 3},
+            "by": "subtype",
+            "groups": {"H1N1": {"matches": ["^M"]}, "H3N2": {"matches": ["K$"]}},
+        },
+    }
+}
+
+
+@pytest.fixture
+def library():
+    """Three strains, the first carrying two barcodes, passing every check in `SPEC`."""
+    return pd.DataFrame(
+        {
+            "barcode": ["ACGT", "ACGA", "TTTT", "GGGG"],
+            "strain": ["A/X/1", "A/X/1", "A/Y/2", "A/Z/3"],
+            "plasmid_id": ["p1", "p2", None, "p4"],
+            "subtype": ["H1N1", "H1N1", "H3N2", "H1N1"],
+            "strain_type": ["vaccine", "vaccine", "circulating", "circulating"],
+            "vaccine_type": ["egg", "egg", None, None],
+            "haplotype": ["A", "A", "A", "B"],
+            "collection_date": ["2020.5", "2020.5", "2021.25", "2019.0"],
+            "nt_seq": ["ATGAAA", "ATGAAA", "AAAAAA", "ATGTGC"],
+            "prot_seq": ["MK", "MK", "KK", "MC"],
+        }
+    )
+
+
+def _set(df, row, **values):
+    """Copy of `df` with `values` assigned to the rows indexed by `row`."""
+    df = df.copy()
+    for col, value in values.items():
+        df.loc[row, col] = value
+    return df
+
+
+# one input per check `id`, breaking that check and only that check. Where a column has
+# to change on every barcode of a strain to leave the other checks alone, it does.
+BREAKERS = {
+    "nulls": lambda df: _set(df, 2, haplotype=None),
+    "values:subtype": lambda df: _set(df, 2, subtype="H5N1"),
+    "values:strain_type": lambda df: _set(df, 3, strain_type="unknown"),
+    "values:vaccine_type": lambda df: _set(df, [0, 1], vaccine_type="cell"),
+    "non_null_when:vaccine_type": lambda df: _set(df, 2, vaccine_type="egg"),
+    "numeric:collection_date": lambda df: _set(df, 3, collection_date="unknown"),
+    "matches:strain:^\\S+$": lambda df: _set(df, [0, 1], strain="A/X 1"),
+    "matches:barcode:^[ACGT]{4}$": lambda df: _set(df, 0, barcode="acgt"),
+    # lowercase still translates, so this fails the format check alone
+    "matches:nt_seq:^([ACGT]{3})+$": lambda df: _set(df, 3, nt_seq="atgtgc"),
+    "matches:prot_seq:^[ACDEFGHIKLMNPQRSTVWY]+$": lambda df: _set(
+        df, 3, nt_seq="ATGTAA", prot_seq="M*"
+    ),
+    "length:prot_seq": lambda df: _set(df, 3, nt_seq="ATGTGCATGTGC", prot_seq="MCMC"),
+    "matches:prot_seq:H1N1:^M": lambda df: _set(df, 3, nt_seq="TGCATG", prot_seq="CM"),
+    "matches:prot_seq:H3N2:K$": lambda df: _set(df, 2, nt_seq="AAAATG", prot_seq="KM"),
+    "unique_barcode:barcode": lambda df: _set(df, 1, barcode="ACGT"),
+    "unique_barcode:plasmid_id": lambda df: _set(df, 3, plasmid_id="p1"),
+    "unique_strain:haplotype": lambda df: _set(df, 3, haplotype="A"),
+    # a synonymous change, so the two strains share a protein but not a coding sequence
+    "unique_strain:prot_seq": lambda df: _set(df, 3, nt_seq="ATGAAG", prot_seq="MK"),
+    "constant_per_strain": lambda df: _set(df, 1, collection_date="2021.0"),
+    "translates_to:nt_seq": lambda df: _set(df, 3, prot_seq="MM"),
+}
+
+
+def validate(df, spec=SPEC, tmp_path=None, name="library.csv"):
+    """Write `df` to a CSV and validate it, returning the report."""
+    csv = tmp_path / name
+    df.to_csv(csv, index=False)
+    return report(csv, spec)
+
+
+class TestValidLibrary:
+    """A library that meets its spec."""
+
+    def test_passes(self, library, tmp_path):
+        """Every check passes, so nothing is raised."""
+        text = validate(library, tmp_path=tmp_path)
+        assert "FAIL" not in text
+
+    def test_report_holds_every_section(self, library, tmp_path):
+        """The report a project tracks says what the library is and what was checked."""
+        text = validate(library, tmp_path=tmp_path)
+        for section in ["schema", "summary of", "columns", "patterns", "uniqueness"]:
+            assert section in text
+
+    def test_report_gives_the_range_of_a_numeric_column(self, library, tmp_path):
+        """A number is summarized rather than merely checked, over strains not barcodes."""
+        assert "`collection_date` over 3 strains:  min 2019.00" in validate(
+            library, tmp_path=tmp_path
+        )
+
+    def test_a_column_the_spec_omits_is_named_rather_than_ignored(
+        self, library, tmp_path
+    ):
+        """An unchecked column is visible in the report instead of passing unnoticed."""
+        text = validate(library.assign(note=["a", "b", "c", "d"]), tmp_path=tmp_path)
+        assert (
+            "columns not listed in `viral_library_validations: columns`: ['note']"
+            in text
+        )
+        assert "NOT VALIDATED" in text
+
+
+class TestEveryCheckFails:
+    """Each configured check fires on an input that breaks it, and on nothing else."""
+
+    @pytest.mark.parametrize("check_id", sorted(BREAKERS))
+    def test_the_right_check_fails(self, check_id, library, tmp_path):
+        """Asserting which check fired, as passing on an earlier one proves nothing."""
+        with pytest.raises(LibraryError) as excinfo:
+            validate(BREAKERS[check_id](library), tmp_path=tmp_path)
+        assert [c.id for c in excinfo.value.failures] == [check_id]
+
+    def test_no_check_goes_untested(self, library):
+        """A check with no breaking input is a check that might never fire."""
+        assert {c.id for c in library_checks(library, SPEC)} == set(BREAKERS)
+
+    def test_a_missing_column_is_reported_before_anything_else(self, library, tmp_path):
+        """Nothing can be checked against a column that is not there."""
+        with pytest.raises(LibraryError, match="missing listed columns"):
+            validate(library.drop(columns="haplotype"), tmp_path=tmp_path)
+
+
+class TestNotCrashing:
+    """Inputs that must be reported as failures rather than raised out of `report`."""
+
+    def test_a_sequence_that_cannot_be_translated_is_reported(self, library, tmp_path):
+        """`ZZZ` is three letters but not a codon, so `Bio` refuses to translate it."""
+        df = _set(library, 3, nt_seq="ZZZATG")
+        with pytest.raises(LibraryError) as excinfo:
+            validate(df, tmp_path=tmp_path)
+        assert "translates_to:nt_seq" in {c.id for c in excinfo.value.failures}
+
+    def test_strain_may_be_declared_distinct_per_barcode(self, library, tmp_path):
+        """A library with one barcode per strain can say so, which `strain` groups by."""
+        spec = {"columns": {**SPEC["columns"]}}
+        spec["columns"]["strain"] = {**spec["columns"]["strain"], "unique": "barcode"}
+        # the fixture's first strain carries two barcodes, so this is what it catches
+        with pytest.raises(LibraryError) as excinfo:
+            validate(library, spec=spec, tmp_path=tmp_path)
+        assert "unique_barcode:strain" in {c.id for c in excinfo.value.failures}
+
+
+class TestFailureReporting:
+    """What a failing run leaves behind."""
+
+    def test_the_report_holds_the_checks_that_passed(self, library, tmp_path):
+        """The wrapper writes this to the log, so a failure says what it got through."""
+        with pytest.raises(LibraryError) as excinfo:
+            validate(BREAKERS["unique_barcode:barcode"](library), tmp_path=tmp_path)
+        assert "=== summary of" in excinfo.value.report
+        assert " OK " in excinfo.value.report
+
+    def test_every_failure_is_reported_not_just_the_first(self, library, tmp_path):
+        """A library with several faults is fixed in one pass rather than in several."""
+        df = _set(library, 3, plasmid_id="p1", collection_date="unknown")
+        with pytest.raises(LibraryError) as excinfo:
+            validate(df, tmp_path=tmp_path)
+        assert {c.id for c in excinfo.value.failures} == {
+            "unique_barcode:plasmid_id",
+            "numeric:collection_date",
+        }
+
+    def test_a_failure_names_the_offending_strains_and_values(self, library, tmp_path):
+        """The message has to be enough to find the rows in the CSV."""
+        with pytest.raises(LibraryError) as excinfo:
+            validate(
+                BREAKERS["matches:barcode:^[ACGT]{4}$"](library), tmp_path=tmp_path
+            )
+        assert "A/X/1: 'acgt'" in excinfo.value.report
+
+
+class TestValidateSpec:
+    """A malformed spec is a configuration error, never a problem with the data."""
+
+    @pytest.mark.parametrize(
+        ("bad", "message"),
+        [
+            ({"columns": {"strain": {"nulls": False}}}, "is missing \\['barcode'\\]"),
+            ({"columns": {}}, "non-empty mapping"),
+            ({"columns": {}, "barcode_length": 16}, "exactly the key `columns`"),
+            ({"columns": {"strain": {}, "barcode": {}}}, "must declare `nulls`"),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "unqiue": "strain"},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "unknown keys",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "unique": "strain"},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "cannot have `unique: strain`",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False},
+                        "barcode": {"nulls": False, "unique": "row"},
+                    }
+                },
+                "expected one of",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False},
+                        "barcode": {"nulls": False, "unique_within": "strain"},
+                    }
+                },
+                "without `unique: strain`",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "values": [True, False]},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "must all be strings",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "matches": ["["]},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "invalid regex",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "length": {"min": 3}},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "exactly `min` and `max`",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "translates_to": "nope"},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "not another column listed",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "by": "barcode", "groups": {}},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "must declare the `values`",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {"nulls": False, "groups": {}},
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "must have `by` and `groups` together",
+            ),
+            (
+                {
+                    "columns": {
+                        "strain": {
+                            "nulls": False,
+                            "non_null_when": {"barcode": "x", "strain": "y"},
+                        },
+                        "barcode": {"nulls": False},
+                    }
+                },
+                "must name exactly one column",
+            ),
+        ],
+    )
+    def test_rejects(self, bad, message):
+        """Each malformed spec is rejected with a message naming what is wrong."""
+        with pytest.raises(SpecError, match=message):
+            validate_spec(bad)
+
+    @pytest.mark.parametrize("key", ["by", "unique_within"])
+    def test_a_grouping_column_may_not_be_null(self, key):
+        """A row with no group has no group's checks to meet, so it must not exist."""
+        spec = {
+            "columns": {
+                "strain": {"nulls": False},
+                "barcode": {"nulls": False},
+                "subtype": {"nulls": True, "values": ["H1N1"]},
+                "other": (
+                    {
+                        "nulls": False,
+                        "by": "subtype",
+                        "groups": {"H1N1": {"matches": ["^M"]}},
+                    }
+                    if key == "by"
+                    else {
+                        "nulls": False,
+                        "unique": "strain",
+                        "unique_within": "subtype",
+                    }
+                ),
+            }
+        }
+        with pytest.raises(SpecError, match="must be declared `nulls: false`"):
+            validate_spec(spec)
+
+    def test_groups_must_cover_exactly_the_values_they_key_on(self):
+        """A group for a value the column cannot hold would never be applied."""
+        spec = {
+            "columns": {
+                "strain": {"nulls": False},
+                "barcode": {"nulls": False},
+                "subtype": {"nulls": False, "values": ["H1N1"]},
+                "prot": {
+                    "nulls": False,
+                    "by": "subtype",
+                    "groups": {
+                        "H1N1": {"matches": ["^M"]},
+                        "H3N2": {"matches": ["^Q"]},
+                    },
+                },
+            }
+        }
+        with pytest.raises(SpecError, match="every value needs an entry"):
+            validate_spec(spec)
+
+    def test_the_valid_spec_is_accepted(self):
+        """The spec the rest of these tests use is itself valid."""
+        validate_spec(SPEC)
+
+    def test_a_bad_spec_is_caught_before_the_library_is_read(self, tmp_path):
+        """`SpecError` rather than a `FileNotFoundError` from a CSV never opened."""
+        with pytest.raises(SpecError):
+            report(tmp_path / "does_not_exist.csv", {"columns": {"strain": {}}})
+
+
+class TestNumericLines:
+    """The range reported for a column declared `numeric`."""
+
+    def test_says_so_when_nothing_parses(self, library):
+        """Otherwise it reads as a second, garbled failure beside the real one."""
+        df = _set(library, [0, 1, 2, 3], collection_date="unknown")
+        (line,) = numeric_lines(df, SPEC)
+        assert "nan" not in line
+        assert "no numeric values" in line
+
+
+class TestDescribeColumn:
+    """The `checks` cell of the report's per-column table."""
+
+    def test_names_each_configured_check(self):
+        """A reader sees what a column was held to without opening `config.yml`."""
+        assert describe_column("barcode", SPEC) == (
+            "non-null; distinct per row; matches ^[ACGT]{4}$"
+        )
+        assert describe_column("haplotype", SPEC) == (
+            "non-null; names one strain within its subtype"
+        )
+
+    def test_says_so_when_a_column_is_not_checked(self):
+        """The point of the table is that an unchecked column cannot hide in it."""
+        assert describe_column("anything_else", SPEC) == "NOT VALIDATED"
+
+
+class TestSummaryLines:
+    """The breakdown of the library that heads the report."""
+
+    def test_breaks_down_every_categorical_column(self, library):
+        """Driven by `values`, so the summary names no column of its own."""
+        text = "\n".join(summary_lines(library, SPEC, "library.csv"))
+        assert "4 barcodes for 3 strains" in text
+        for column in ["subtype", "strain_type", "vaccine_type"]:
+            assert f"  {column}" in text
+
+    def test_counts_strains_and_barcodes_separately(self, library):
+        """A strain carrying several barcodes must not be counted several times."""
+        text = "\n".join(summary_lines(library, SPEC, "library.csv"))
+        assert "    H1N1         2         3" in text


### PR DESCRIPTION
## Why
Six projects had grown their own copy of a `validate_viral_library` rule and
script, diverged across two configuration schemas and two schema-less scripts,
so fixes in one never reached the others. This replaces them with one
implementation here.

## What
An optional `viral_library_validations` key, keyed per library, declaring what
each column must hold. The rule writes a report to
`results/validate_viral_library/{viral_library}_validation.txt` and fails the
run on any check that does not pass. Only `barcode` and `strain` need
declaring, as they are the only columns the pipeline itself reads, so one
schema covers both the two-column test libraries and a twelve-column flu
library. The report tabulates every column of the CSV, so one going unchecked
is visible rather than silent. See the new README section for the keys.

## Compatibility
The key is optional, so a project that does not set it runs exactly as before.
A project that has a local copy of this rule must delete it in the same commit
that bumps this submodule, as `snakemake` will not parse two rules of the same
name.

## Configuration and environment changes
- `test_example/config.yml` gains a minimal block for its two libraries.
- `test_example/.gitignore` tracks the new report.
- `environment.yml` gains `biopython`, which the translation check imports and
  which was previously present only as a transitive dependency of
  `dms_variants`. This changes the environment hash, so projects re-solve their
  conda environment on upgrade.

## Testing
55 pytest cases in `tests/test_viral_library_validation.py`: each check has an
input that breaks it and no other check, and a test fails if a check is ever
added without one. A new GitHub Actions job runs the pipeline against a
deliberately wrong configuration and requires `snakemake` to exit non-zero with
the failure named in the log — the first test here of a failure rather than a
success. Also verified against the twelve-column `flu-seqneut-DRIVEstudy`
libraries: all checks passing, with counts matching that project's existing
report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)